### PR TITLE
Initial shot at an inline edit UI

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -533,8 +533,10 @@ class Ad_Code_Manager
 				update_post_meta( $ad_code_id, $slug, $ad_code[$slug] );
 			}
 			update_post_meta( $ad_code_id, 'priority', $ad_code['priority'] );
-		} 
-		return;
+		}
+		$this->flush_cache();
+		wp_redirect( wp_get_referer() );
+		exit();
 	}
 
 	/**

--- a/common/css/acm.css
+++ b/common/css/acm.css
@@ -14,7 +14,7 @@
   width: 600px;
 }
 
-#the-list:hover .row-actions {
+tr:hover .row-actions {
 	visibility: visible;
 }
 
@@ -34,4 +34,51 @@
     clear:left;
     width: 90%;
     text-align: right;
+}
+
+.acm-edit-field {
+    position: relative;
+    max-width: 200px;
+    float: left;
+    margin: 15px 0 0 15px;
+}
+
+.acm-edit-field label {
+    position: relative;
+    float: left;
+    font-weight: 700;
+    color: #333;
+}
+
+.acm-edit-cond,
+.acm-cancel-button,
+.acm-edit-field input,
+.acm-conditional-label {
+    position: relative;
+    float: left;
+    clear: left;
+}
+
+.acm-edit-cond {
+    margin: 5px 0 0 15px;
+}
+
+.acm-edit-cond input {
+    margin-left: 15px;
+}
+
+.acm-conditional-label {
+    width: 100%;
+    font-weight: 700;
+    color: #333;
+    margin: 10px 0 0 15px;
+}
+
+.acm-cancel-button {
+    margin: 10px 0 30px 15px;
+}
+
+.acm-edit-button {
+    float: left;
+    margin: 10px 0 30px 15px;
 }

--- a/common/js/acm.js
+++ b/common/js/acm.js
@@ -13,4 +13,28 @@ jQuery( document ).ready( function( $ ) {
 		
 		el.toggleClass('hidden');
 	});
-} );
+    jQuery('.ad-code-edit').click( function( $ ) {
+        var url_request = ajaxurl + jQuery(this).val();
+        var data = {
+            action: 'acm_edit_ad_code',
+            data: post_id,
+            nonce: $( '#acm_edit_ad_code_nonce' ).val()
+        };
+        $.post( ajaxurl, data, function( response ) {
+            $('.edit_acm_view').replaceWith( response );
+        } );
+    });
+    jQuery('.acm-ajax-edit').click( function($) {
+        var post_id = parseInt( jQuery(this).attr('id').split('-')[1] );
+        jQuery('.acm-edit-display').hide();
+        jQuery('.acm-record-display').show();
+        jQuery('#record_' + post_id ).hide();
+        jQuery('#acm-conditional-0 option').clone().appendTo('.cond_' + post_id );
+        jQuery('#record_display_' + post_id ).show();
+        jQuery('#acm-cancel-edit-' + post_id ).click( function($) {
+            jQuery('.acm-edit-display').hide();
+            jQuery('.acm-record-display').show();
+        });
+
+    });
+});


### PR DESCRIPTION
Adds row actions in the ACM list table for View Conditionals, Edit, and Delete.

Connects each row's 'Edit' option to a hidden row containing a form with
all of the current Ad Code data.

Handles the basic Ad Code meta on a POST request, and updates accordingly,
but does not yet handle changes to the conditionals. Redirects back to the
referring site once saved.

Hopefully this approach isn't too far off, though I don't think it would
be too difficult to change course if it is.

View Conditionals and Delete are not yet hooked up to anything.

Side note - while preparing the conditionals, I noticed that multiple
arguments are possible for each. I tried saving an array() with multiple
arguments for a conditional, but it was still stored as a string. I didn't
investigate too much, but for now am displaying only argument 0 in the
inline display, as I didn't want to get distracted thinking out that
scenario.
