### PR TITLE
Fix PHP warning with empty list table

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -457,13 +457,18 @@ class Ad_Code_Manager
 	 */
 	function edit_conditionals( $ad_code_id, $conditionals = array() ) {
 		if ( 0 !== $ad_code_id && !empty( $conditionals ) ) {
+			$new_conditionals = array();
 			foreach( $conditionals as $conditional ) {
-					$new_conditionals[] = array(
-						'function' => $conditional['function'],
-						'arguments' => (array) $conditional['arguments'],
-					);
+				if ( '' == $conditional['function'] )
+					continue;
+				$new_conditionals[] = array(
+					'function' => $conditional['function'],
+					'arguments' => (array) $conditional['arguments'],
+				);
 			}
 			return update_post_meta( $ad_code_id, 'conditionals', $new_conditionals );
+		} elseif ( 0 !== $ad_code_id ) {
+			return update_post_meta( $ad_code_id, 'conditionals', array() );
 		}
 	}
 

--- a/common/css/acm.css
+++ b/common/css/acm.css
@@ -95,3 +95,17 @@ tr:hover .row-actions {
 	color: #333;
 	text-decoration: underline;
 }
+
+#acm-add-inline-cond {
+	display: block;
+	float: left;
+	clear: left;
+	padding-top: 5px;
+	width: 295px;
+	text-align: right;
+	cursor:pointer;
+}
+
+#acm-add-inline-cond:hover {
+	text-decoration: underline;
+}

--- a/common/js/acm.js
+++ b/common/js/acm.js
@@ -35,17 +35,23 @@ jQuery( document ).ready( function( $ ) {
             jQuery('.acm-edit-display').hide();
             jQuery('.acm-record-display').show();
         });
-	    if ( 1 == jQuery('.acm-edit-cond', '#record_display_' + post_id ).length ) {
-		    jQuery('.acm-x-cond', '#record_display_' + post_id ).remove();
-	    } else {
-		    jQuery('.acm-x-cond').click( function($) {
-			    var record_id = parseInt( jQuery(this).attr('id').split('-')[1] );
-			    jQuery('#acm-edit-cond-' + record_id ).remove();
-			    if ( 1 == jQuery('.acm-edit-cond', '#record_display_' + post_id ).length ) {
-				    jQuery('.acm-x-cond', '#record_display_' + post_id ).remove();
-			    }
+	    jQuery('.acm-x-cond').click( function($) {
+		    var record_id = parseInt( jQuery(this).attr('id').split('-')[1] );
+		    jQuery('#acm-edit-cond-' + record_id ).remove();
+	    });
+	    var current_index = jQuery('.acm-edit-cond', '#record_display_' + post_id ).length;
+	    jQuery('#acm-add-inline-cond', '#record_display_' + post_id ).click( function($){
+		    jQuery('.acm-edit-cond', '#record_display_' + post_id ).last().after('<div class="acm-edit-cond" id="acm-edit-cond-' + current_index + '">' +
+			    '<select name="conditionals[' + current_index + '][function]" id="acm-new-inline-cond-' + current_index + '" class="cond_' + post_id + '"></select>' +
+			    '<input name="conditionals[' + current_index + '][arguments]" type="text" size="20" value="" />' +
+			    '<span class="acm-x-cond" id="acmxcond-' + current_index + '">x</span></div>');
+		    jQuery('#acm-conditional-0 option').clone().appendTo('#acm-new-inline-cond-' + current_index );
+		    jQuery('#acmxcond-' + current_index ).click( function($){
+				var this_index = jQuery(this).attr('id').split('-')[1];
+			    jQuery('#acm-edit-cond-' + this_index ).remove();
 		    });
-	    }
+		    current_index++;
+		});
     });
 	jQuery('.acm-ajax-delete').click( function($) {
 		var $this = jQuery(this);

--- a/common/lib/acm-wp-list-table.php
+++ b/common/lib/acm-wp-list-table.php
@@ -135,7 +135,7 @@ class ACM_WP_List_Table extends WP_List_Table {
 				$value = isset( $rec[$key] ) ? $rec[$key] : $rec['url_vars'][$key];
 				$extra = '';
 				if ( 1 == $i ) {
-					// @todo Only Edit is hooked up via JS right now
+					// @todo View Conditionals not connected yet
 					$extra .= $this->row_actions( array(
 						'View Conditionals' => '<a class="acm-ajax-view" id="acmview-' . $rec[ 'post_id' ] . '" href="#">View Conditionals</a>',
 						'Edit' => '<a class="acm-ajax-edit" id="acmedit-' . $rec[ 'post_id' ] . '" href="#">Edit</a>',
@@ -164,7 +164,7 @@ class ACM_WP_List_Table extends WP_List_Table {
 					$inline_edit_conditionals .= '<div class="acm-edit-cond" id="acm-edit-cond-' . $j . '"><select name="conditionals[' . $j . '][function]" class="cond_' . $rec[ 'post_id' ] . '"><option value="' . esc_attr( $conditionals[$j][ 'function' ] ) . '">' . $conditionals[$j][ 'function' ] . '</option></select>';
 
 					if ( ! empty( $conditionals[$j][ 'arguments' ][0] ) ) {
-						$inline_edit_conditionals .= ' <input name="conditionals[' . $j . '][arguments]" type="text" size="20" value="' . esc_attr( $conditionals[$j][ 'arguments' ][0] ) . '" />';
+						$inline_edit_conditionals .= '<input name="conditionals[' . $j . '][arguments]" type="text" size="20" value="' . esc_attr( $conditionals[$j][ 'arguments' ][0] ) . '" />';
 					} else {
 						$inline_edit_conditionals .= '<input name="conditionals[' . $j . '][arguments]" type="text" size="20" value="" />';
 					}
@@ -186,6 +186,8 @@ class ACM_WP_List_Table extends WP_List_Table {
 							<?php echo $inline_edit_inputs; ?>
 							<label class="acm-conditional-label" for="acm-conditionals">Conditionals:</label>
 							<?php echo $inline_edit_conditionals; ?>
+							<div class="acm-edit-cond"></div>
+							<a id="acm-add-inline-cond">Add more</a>
 						</div></fieldset>
 						<p class="inline-edit-save submit">
 							<?php submit_button( __( 'Cancel', 'ad-code-manager' ), 'secondary', 'acm-cancel-edit-' . $rec[ 'post_id' ], false ); ?> 


### PR DESCRIPTION
PHP was throwing a warning "array_slice() expects parameter 1 to be
array, boolean given", when $this->items was empty.

Add a check for an empty array and return early if it matches. Allows the
no records found message to display.
