### PR TITLE
Move the keydown event to `td` to enable enter to save in quick edit

### DIFF
--- a/common/js/acm.js
+++ b/common/js/acm.js
@@ -19,7 +19,7 @@ inlineEditAdCodes = {
 
 		$('a.cancel', row).click(function() { return inlineEditAdCodes.revert(); });
 		$('a.save', row).click(function() { return inlineEditAdCodes.save(this); });
-		$('input, select', row).keydown(function(e) { if(e.which == 13) return inlineEditAdCodes.save(this); });
+		$('td', row).keydown(function(e) { if(e.which == 13) return inlineEditAdCodes.save(this); });
 
 		$('#posts-filter input[type="submit"]').mousedown(function(e){
 			t.revert();


### PR DESCRIPTION
For some reason the keydown event wasn't firing when it was attached to `input` and `select` elements in the quick edit form. By copying core's method and attaching the keydown to `td`, Enter now works to save the inline form properly.

Fixes #53 
