### PR TITLE
default size of "medium rectangle" in DFP asynch provider

### DIFF
--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -17,11 +17,11 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 					'enable_ui_mapping' => true,
 				),
 			array(
-					'tag'       => '320x250',
+					'tag'       => '300x250',
 					'url_vars'  => array(
-							'tag'       => '320x250',
-							'sz'        => '320x250',
-							'height'    => '320',
+							'tag'       => '300x250',
+							'sz'        => '300x250',
+							'height'    => '300',
 							'width'     => '250',
 						),
 					'enable_ui_mapping' => true,


### PR DESCRIPTION
corrected wrong default size of "medium rectangle" from 320x250 to 300x250

are there any dependencies related beside this file for dfp asynch default setting?
