### PR TITLE
Prefix tag ids in DoubleClick Async provider

### DIFF
--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -134,7 +134,7 @@ foreach ( (array) $ad_tags as $tag ):
 	$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );
 	if ( ! empty( $matching_ad_code ) ) {
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
 <?php
 	}
 endforeach;
@@ -150,9 +150,9 @@ googletag.enableServices();
 			break;	
 		default:
 			$output_script = "
-		<div id='%tag_id%' style='width:%width%px; height:%height%px;'>
+		<div id='acm-ad-tag-%tag_id%' style='width:%width%px; height:%height%px;'>
 <script type='text/javascript'>
-googletag.cmd.push(function() { googletag.display('%tag_id%'); });
+googletag.cmd.push(function() { googletag.display('acm-ad-tag-%tag_id%'); });
 </script>
 		</div>
 		";


### PR DESCRIPTION
Prefixes the tag ids, because ids must not start with a number in html.
This allows the regions to be styled with css.

Fixes #73
