### PR TITLE
Added targeting to DFP async provider

### DIFF
--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -159,28 +159,29 @@ node.parentNode.insertBefore(gads, node);
 <script type='text/javascript'>
 googletag.cmd.push(function() {
 <?php
+
+			/**
+			 * Get keywords for targeting through DFP
+			 */
+			$keyword_targeting = '';
+			if ( is_single() ) {
+				global $wp_query;
+				$post_id = $wp_query->post->ID;
+				$args = array( 'fields' => 'names' );
+				$post_tags = wp_get_post_tags( $post_id, $args );
+				$post_tags = "['" . implode( "','", $post_tags ) . "']";
+				$keyword_targeting = ".setTargeting('kw',$post_tags)";
+			}
+			/**
+			 * Get extra parameters for targeting through DFP
+			 */
+			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
+			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+				
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;
-
-				/**
-				 * Get keywords for targeting through DFP
-				 */
-				$keyword_targeting = '';
-				if ( is_single() ) {
-					global $wp_query;
-					$post_id = $wp_query->post->ID;
-					$args = array( 'fields' => 'names' );
-					$post_tags = wp_get_post_tags( $post_id, $args );
-					$post_tags = "['" . implode( "','", $post_tags ) . "']";
-					$keyword_targeting = ".setTargeting('kw',$post_tags)";
-				}
-				/**
-				 * Get extra parameters for targeting through DFP
-				 */
-				$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
-				$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-				$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
 
 				$tt = $tag['url_vars'];
 				$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -141,7 +141,8 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 			$ad_tags = $ad_code_manager->ad_tag_ids;
 
 			// Allow users to set targeting parameters
-			$set_targeting = apply_filters( 'acm_add_set_targets', '' );
+			$targeting_params_array = apply_filters( 'acm_targeting_params', array() );
+			$targeting_string = $this->format_targeting_string( $targeting_params_array );
 
 			ob_start();
 ?>
@@ -206,6 +207,22 @@ googletag.cmd.push(function() { googletag.display('acm-ad-tag-%tag_id%'); });
 	 */
 	public function action_wp_head() {
 		do_action( 'acm_tag', 'dfp_head' );
+	}
+
+	/**
+	 * Format setTargeting string
+	 * @param  array  $params_array [description]
+	 * @return string               [description]
+	 */
+	function format_targeting_string( $params_array = array() ) {
+		$ret = '';
+		var_dump($params_array);
+		// Iterate over array of key value pairs and format a string
+		foreach( (array) $params_array as $key => $value ) {
+			echo "$key is $value";
+		}
+ 
+		return $ret;
 	}
 
 }

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -141,8 +141,11 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 			$ad_tags = $ad_code_manager->ad_tag_ids;
 
 			// Allow users to set targeting parameters
+			$targeting_string = '';
 			$targeting_params_array = apply_filters( 'acm_targeting_params', array() );
-			$targeting_string = $this->format_targeting_string( $targeting_params_array );
+			if ( ! empty( $targeting_params_array ) ) {
+				$targeting_string = $this->format_targeting_string( $targeting_params_array );
+			}
 
 			ob_start();
 ?>
@@ -175,7 +178,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $targeting_string; ?>;
 <?php
 				}
 			endforeach;
@@ -216,10 +219,11 @@ googletag.cmd.push(function() { googletag.display('acm-ad-tag-%tag_id%'); });
 	 */
 	function format_targeting_string( $params_array = array() ) {
 		$ret = '';
-		var_dump($params_array);
 		// Iterate over array of key value pairs and format a string
 		foreach( (array) $params_array as $key => $value ) {
-			echo "$key is $value";
+			if ( ! empty( $key ) && ! empty( $value ) ) {
+				$ret .= ".setTargeting('" . esc_js( $key ) ."','" . esc_js( $value ) . "')";
+			}
 		}
  
 		return $ret;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -139,26 +139,6 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 		switch ( $tag_id ) {
 		case 'dfp_head':
 			$ad_tags = $ad_code_manager->ad_tag_ids;
-			ob_start();
-?>
-	<!-- Include google_services.js -->
-<script type='text/javascript'>
-var googletag = googletag || {};
-googletag.cmd = googletag.cmd || [];
-(function() {
-var gads = document.createElement('script');
-gads.async = true;
-gads.type = 'text/javascript';
-var useSSL = 'https:' == document.location.protocol;
-gads.src = (useSSL ? 'https:' : 'http:') +
-'//www.googletagservices.com/tag/js/gpt.js';
-var node = document.getElementsByTagName('script')[0];
-node.parentNode.insertBefore(gads, node);
-})();
-</script>
-<script type='text/javascript'>
-googletag.cmd.push(function() {
-<?php
 
 			/**
 			 * Get keywords for targeting through DFP
@@ -186,6 +166,26 @@ googletag.cmd.push(function() {
 
 			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
 
+			ob_start();
+?>
+	<!-- Include google_services.js -->
+<script type='text/javascript'>
+var googletag = googletag || {};
+googletag.cmd = googletag.cmd || [];
+(function() {
+var gads = document.createElement('script');
+gads.async = true;
+gads.type = 'text/javascript';
+var useSSL = 'https:' == document.location.protocol;
+gads.src = (useSSL ? 'https:' : 'http:') +
+'//www.googletagservices.com/tag/js/gpt.js';
+var node = document.getElementsByTagName('script')[0];
+node.parentNode.insertBefore(gads, node);
+})();
+</script>
+<script type='text/javascript'>
+googletag.cmd.push(function() {
+<?php
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -163,16 +163,35 @@ googletag.cmd.push(function() {
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;
 
+				/**
+				 * Get keywords for targeting through DFP
+				 */
+				$keyword_targeting = '';
+				if ( is_single() ) {
+					global $wp_query;
+					$post_id = $wp_query->post->ID;
+					$args = array( 'fields' => 'names' );
+					$post_tags = wp_get_post_tags( $post_id, $args );
+					$post_tags = "['" . implode( "','", $post_tags ) . "']";
+					$keyword_targeting = ".setTargeting('kw',$post_tags)";
+				}
+				/**
+				 * Get extra parameters for targeting through DFP
+				 */
+				$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+				$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
+				$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+
 				$tt = $tag['url_vars'];
-			$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );
-			if ( ! empty( $matching_ad_code ) ) {
-				// @todo There might be a case when there are two tags registered with the same dimensions
-				// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
-				// that tags are unique
+				$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );
+				if ( ! empty( $matching_ad_code ) ) {
+					// @todo There might be a case when there are two tags registered with the same dimensions
+					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
+					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting ?>;
 <?php
-			}
+				}
 			endforeach;
 ?>
 googletag.pubads().enableSingleRequest();

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -214,11 +214,12 @@ googletag.cmd.push(function() { googletag.display('acm-ad-tag-%tag_id%'); });
 
 	/**
 	 * Format setTargeting string
-	 * @param  array  $params_array [description]
-	 * @return string               [description]
+	 * @param  array  $params_array Key value pair you'd like to target. Example: ["title"]=>"Your post's title"
+	 * @return string               The targeting string to append to slot definition
 	 */
 	function format_targeting_string( $params_array = array() ) {
 		$ret = '';
+		var_dump($params_array);
 		// Iterate over array of key value pairs and format a string
 		foreach( (array) $params_array as $key => $value ) {
 			if ( ! empty( $key ) && ! empty( $value ) ) {

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -140,31 +140,8 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 		case 'dfp_head':
 			$ad_tags = $ad_code_manager->ad_tag_ids;
 
-			/**
-			 * Get keywords for targeting through DFP
-			 */
-			$keyword_targeting = '';
-			if ( is_single() ) {
-				global $wp_query;
-				$post_id = $wp_query->post->ID;
-				$args = array( 'fields' => 'names' );
-				$post_tags = wp_get_post_tags( $post_id, $args ); // get tag names
-				$post_categories = wp_get_post_categories( $post_id, $args ); // get category names
-				$post_keywords_arr = array_unique( array_merge( $post_tags, $post_categories ) ); // remove dupes and merge
-				$post_keywords = implode( "','", $post_keywords_arr ); // make keyword list for JS
-				$keyword_targeting = ".setTargeting('kw',['$post_keywords'])";
-			}
-			/**
-			 * Get extra parameters for targeting through DFP
-			 */
-			$title_targeting = ".setTargeting('title','" . esc_js( get_the_title( $post_id ) ) . "')";
-			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-			$fullpath_targeting = ".setTargeting('fullPath','" . get_option( 'siteurl' ) . $_SERVER['REQUEST_URI'] . "')";
-			$domain_parts = parse_url( get_option( 'siteurl' ) );
-			$domain_name = $domain_parts['host'];
-			$domain_targeting = ".setTargeting('domainName','" . $domain_name . "')";
-
-			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
+			// Allow users to set targeting parameters
+			$set_targeting = apply_filters( 'acm_add_set_targets', '' );
 
 			ob_start();
 ?>
@@ -197,7 +174,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $targeting_string; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -177,9 +177,14 @@ googletag.cmd.push(function() {
 			/**
 			 * Get extra parameters for targeting through DFP
 			 */
-			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+			$title_targeting = ".setTargeting('title','" . esc_js( get_the_title( $post_id ) ) . "')";
 			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+			$fullpath_targeting = ".setTargeting('fullPath','" . get_option( 'siteurl' ) . $_SERVER['REQUEST_URI'] . "')";
+			$domain_parts = parse_url( get_option( 'siteurl' ) );
+			$domain_name = $domain_parts['host'];
+			$domain_targeting = ".setTargeting('domainName','" . $domain_name . "')";
+
+			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
 
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
@@ -192,7 +197,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $targeting_string; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -168,11 +168,11 @@ googletag.cmd.push(function() {
 				global $wp_query;
 				$post_id = $wp_query->post->ID;
 				$args = array( 'fields' => 'names' );
-				$post_tags = wp_get_post_tags( $post_id, $args );
-				$post_tags = implode( "','", $post_tags );
-				$post_categories = wp_get_post_categories( $post_id, $args );
-				$post_categories = implode( "','", $post_categories );
-				$keyword_targeting = ".setTargeting('kw',['$post_tags','$post_categories'])";
+				$post_tags = wp_get_post_tags( $post_id, $args ); // get tag names
+				$post_categories = wp_get_post_categories( $post_id, $args ); // get category names
+				$post_keywords_arr = array_unique( array_merge( $post_tags, $post_categories ) ); // remove dupes and merge
+				$post_keywords = implode( "','", $post_keywords_arr ); // make keyword list for JS
+				$keyword_targeting = ".setTargeting('kw',['$post_keywords'])";
 			}
 			/**
 			 * Get extra parameters for targeting through DFP

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -169,8 +169,10 @@ googletag.cmd.push(function() {
 				$post_id = $wp_query->post->ID;
 				$args = array( 'fields' => 'names' );
 				$post_tags = wp_get_post_tags( $post_id, $args );
-				$post_tags = "['" . implode( "','", $post_tags ) . "']";
-				$keyword_targeting = ".setTargeting('kw',$post_tags)";
+				$post_tags = implode( "','", $post_tags );
+				$post_categories = wp_get_post_categories( $post_id, $args );
+				$post_categories = implode( "','", $post_categories );
+				$keyword_targeting = ".setTargeting('kw',['$post_tags','$post_categories'])";
 			}
 			/**
 			 * Get extra parameters for targeting through DFP
@@ -178,7 +180,7 @@ googletag.cmd.push(function() {
 			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
 			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
 			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
-				
+
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;


### PR DESCRIPTION
Modified the DFP async provider code to pass keywords, title, path and domain to the defineSlot method. This will allow users to target specific ads based on these attributes through DFP itself.