### PR TITLE
Allow DFP async slots to accept multiple ad sizes

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -1076,8 +1076,8 @@ class Ad_Code_Manager {
 
 	/**
 	 * Allow ad sizes to be defined as arrays or as basic width x height.
-	 * The purpose of this is to solve for flex spaces, where multiple ad
-	 * sizes may be required to load in the same ad unit
+	 * The purpose of this is to solve for flex units, where multiple ad
+	 * sizes may be required to load in the same ad unit.
 	 */
 	function parse_ad_tag_sizes( $url_vars ) {
 		if ( empty( $url_vars ) ) 

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -1074,6 +1074,27 @@ class Ad_Code_Manager {
 		return $this->action_acm_tag( $id, false );
 	}
 
+	/**
+	 * Allow ad sizes to be defined as arrays or as basic width x height.
+	 * The purpose of this is to solve for flex spaces, where multiple ad
+	 * sizes may be required to load in the same ad unit
+	 */
+	function parse_ad_tag_sizes( $url_vars ) {
+		if ( empty( $url_vars ) ) 
+			return;
+
+		$unit_sizes_output = '';
+		if ( ! empty( $url_vars['sizes'] ) ) {
+			foreach( $url_vars['sizes'] as $unit_size ) {
+				$unit_sizes_output .= '[' . (int)$unit_size['width'] . ',' . (int)$unit_size['height'] . '],';
+			}
+			$unit_sizes_output = trim( $unit_sizes_output, ',' );
+		} else { // fallback for old style width x height
+			$unit_sizes_output = (int)$url_vars['width'] . ',' . (int)$url_vars['height'];
+		}
+		return $unit_sizes_output;
+	}
+
 }
 
 global $ad_code_manager;

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -1074,27 +1074,6 @@ class Ad_Code_Manager {
 		return $this->action_acm_tag( $id, false );
 	}
 
-	/**
-	 * Allow ad sizes to be defined as arrays or as basic width x height.
-	 * The purpose of this is to solve for flex units, where multiple ad
-	 * sizes may be required to load in the same ad unit.
-	 */
-	function parse_ad_tag_sizes( $url_vars ) {
-		if ( empty( $url_vars ) ) 
-			return;
-
-		$unit_sizes_output = '';
-		if ( ! empty( $url_vars['sizes'] ) ) {
-			foreach( $url_vars['sizes'] as $unit_size ) {
-				$unit_sizes_output .= '[' . (int)$unit_size['width'] . ',' . (int)$unit_size['height'] . '],';
-			}
-			$unit_sizes_output = trim( $unit_sizes_output, ',' );
-		} else { // fallback for old style width x height
-			$unit_sizes_output = (int)$url_vars['width'] . ',' . (int)$url_vars['height'];
-		}
-		return $unit_sizes_output;
-	}
-
 }
 
 global $ad_code_manager;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -171,7 +171,7 @@ googletag.cmd.push(function() {
 					// that tags are unique	
 
 					// Parse ad tags to output flexible unit dimensions
-					$unit_sizes = $ad_code_manager->parse_ad_tag_sizes( $tt );
+					$unit_sizes = $this->parse_ad_tag_sizes( $tt );
 
 ?>
 googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
@@ -206,6 +206,27 @@ googletag.cmd.push(function() { googletag.display('acm-ad-tag-%tag_id%'); });
 	 */
 	public function action_wp_head() {
 		do_action( 'acm_tag', 'dfp_head' );
+	}
+
+	/**
+	 * Allow ad sizes to be defined as arrays or as basic width x height.
+	 * The purpose of this is to solve for flex units, where multiple ad
+	 * sizes may be required to load in the same ad unit.
+	 */
+	public function parse_ad_tag_sizes( $url_vars ) {
+		if ( empty( $url_vars ) ) 
+			return;
+
+		$unit_sizes_output = '';
+		if ( ! empty( $url_vars['sizes'] ) ) {
+			foreach( $url_vars['sizes'] as $unit_size ) {
+				$unit_sizes_output .= '[' . (int)$unit_size['width'] . ',' . (int)$unit_size['height'] . '],';
+			}
+			$unit_sizes_output = trim( $unit_sizes_output, ',' );
+		} else { // fallback for old style width x height
+			$unit_sizes_output = (int)$url_vars['width'] . ',' . (int)$url_vars['height'];
+		}
+		return $unit_sizes_output;
 	}
 
 }

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -159,28 +159,29 @@ node.parentNode.insertBefore(gads, node);
 <script type='text/javascript'>
 googletag.cmd.push(function() {
 <?php
+
+			/**
+			 * Get keywords for targeting through DFP
+			 */
+			$keyword_targeting = '';
+			if ( is_single() ) {
+				global $wp_query;
+				$post_id = $wp_query->post->ID;
+				$args = array( 'fields' => 'names' );
+				$post_tags = wp_get_post_tags( $post_id, $args );
+				$post_tags = "['" . implode( "','", $post_tags ) . "']";
+				$keyword_targeting = ".setTargeting('kw',$post_tags)";
+			}
+			/**
+			 * Get extra parameters for targeting through DFP
+			 */
+			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
+			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+				
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;
-
-				/**
-				 * Get keywords for targeting through DFP
-				 */
-				$keyword_targeting = '';
-				if ( is_single() ) {
-					global $wp_query;
-					$post_id = $wp_query->post->ID;
-					$args = array( 'fields' => 'names' );
-					$post_tags = wp_get_post_tags( $post_id, $args );
-					$post_tags = "['" . implode( "','", $post_tags ) . "']";
-					$keyword_targeting = ".setTargeting('kw',$post_tags)";
-				}
-				/**
-				 * Get extra parameters for targeting through DFP
-				 */
-				$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
-				$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-				$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
 
 				$tt = $tag['url_vars'];
 				$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -174,20 +174,11 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique	
 
-					/**
-					* Get unit size as array of widths x heights in case of flex spaces
-					*/
-					$unit_sizes_output = '';
-					if ( ! empty( $tt['sizes'] ) ) {
-						foreach( $tt['sizes'] as $unit_size ) {
-							$unit_sizes_output .= '[' . (int)$unit_size['width'] . ',' . (int)$unit_size['height'] . '],';
-						}
-						$unit_sizes_output = trim( $unit_sizes_output, ',' );
-					} else { // fallback for old style width x height
-						$unit_sizes_output = (int)$tt['width'] . ',' . (int)$tt['height'];
-					}
+					// Get unit size as array of widths x heights in case of flex spaces					
+					$unit_sizes = $ad_code_manager->parse_ad_tag_sizes( $tt );
+
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes_output; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -139,26 +139,6 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 		switch ( $tag_id ) {
 		case 'dfp_head':
 			$ad_tags = $ad_code_manager->ad_tag_ids;
-			ob_start();
-?>
-	<!-- Include google_services.js -->
-<script type='text/javascript'>
-var googletag = googletag || {};
-googletag.cmd = googletag.cmd || [];
-(function() {
-var gads = document.createElement('script');
-gads.async = true;
-gads.type = 'text/javascript';
-var useSSL = 'https:' == document.location.protocol;
-gads.src = (useSSL ? 'https:' : 'http:') +
-'//www.googletagservices.com/tag/js/gpt.js';
-var node = document.getElementsByTagName('script')[0];
-node.parentNode.insertBefore(gads, node);
-})();
-</script>
-<script type='text/javascript'>
-googletag.cmd.push(function() {
-<?php
 
 			/**
 			 * Get keywords for targeting through DFP
@@ -186,6 +166,26 @@ googletag.cmd.push(function() {
 
 			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
 
+			ob_start();
+?>
+	<!-- Include google_services.js -->
+<script type='text/javascript'>
+var googletag = googletag || {};
+googletag.cmd = googletag.cmd || [];
+(function() {
+var gads = document.createElement('script');
+gads.async = true;
+gads.type = 'text/javascript';
+var useSSL = 'https:' == document.location.protocol;
+gads.src = (useSSL ? 'https:' : 'http:') +
+'//www.googletagservices.com/tag/js/gpt.js';
+var node = document.getElementsByTagName('script')[0];
+node.parentNode.insertBefore(gads, node);
+})();
+</script>
+<script type='text/javascript'>
+googletag.cmd.push(function() {
+<?php
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -163,16 +163,35 @@ googletag.cmd.push(function() {
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;
 
+				/**
+				 * Get keywords for targeting through DFP
+				 */
+				$keyword_targeting = '';
+				if ( is_single() ) {
+					global $wp_query;
+					$post_id = $wp_query->post->ID;
+					$args = array( 'fields' => 'names' );
+					$post_tags = wp_get_post_tags( $post_id, $args );
+					$post_tags = "['" . implode( "','", $post_tags ) . "']";
+					$keyword_targeting = ".setTargeting('kw',$post_tags)";
+				}
+				/**
+				 * Get extra parameters for targeting through DFP
+				 */
+				$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+				$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
+				$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+
 				$tt = $tag['url_vars'];
-			$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );
-			if ( ! empty( $matching_ad_code ) ) {
-				// @todo There might be a case when there are two tags registered with the same dimensions
-				// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
-				// that tags are unique
+				$matching_ad_code = $ad_code_manager->get_matching_ad_code( $tag['tag'] );
+				if ( ! empty( $matching_ad_code ) ) {
+					// @todo There might be a case when there are two tags registered with the same dimensions
+					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
+					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting ?>;
 <?php
-			}
+				}
 			endforeach;
 ?>
 googletag.pubads().enableSingleRequest();

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -170,7 +170,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique	
 
-					// Get unit size as array of widths x heights in case of flex spaces					
+					// Parse ad tags to output flexible unit dimensions
 					$unit_sizes = $ad_code_manager->parse_ad_tag_sizes( $tt );
 
 ?>

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -140,31 +140,8 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 		case 'dfp_head':
 			$ad_tags = $ad_code_manager->ad_tag_ids;
 
-			/**
-			 * Get keywords for targeting through DFP
-			 */
-			$keyword_targeting = '';
-			if ( is_single() ) {
-				global $wp_query;
-				$post_id = $wp_query->post->ID;
-				$args = array( 'fields' => 'names' );
-				$post_tags = wp_get_post_tags( $post_id, $args ); // get tag names
-				$post_categories = wp_get_post_categories( $post_id, $args ); // get category names
-				$post_keywords_arr = array_unique( array_merge( $post_tags, $post_categories ) ); // remove dupes and merge
-				$post_keywords = implode( "','", $post_keywords_arr ); // make keyword list for JS
-				$keyword_targeting = ".setTargeting('kw',['$post_keywords'])";
-			}
-			/**
-			 * Get extra parameters for targeting through DFP
-			 */
-			$title_targeting = ".setTargeting('title','" . esc_js( get_the_title( $post_id ) ) . "')";
-			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-			$fullpath_targeting = ".setTargeting('fullPath','" . get_option( 'siteurl' ) . $_SERVER['REQUEST_URI'] . "')";
-			$domain_parts = parse_url( get_option( 'siteurl' ) );
-			$domain_name = $domain_parts['host'];
-			$domain_targeting = ".setTargeting('domainName','" . $domain_name . "')";
-
-			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
+			// Allow users to set targeting parameters
+			$set_targeting = apply_filters( 'acm_add_set_targets', '' );
 
 			ob_start();
 ?>
@@ -197,7 +174,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $targeting_string; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -139,10 +139,6 @@ class Doubleclick_For_Publishers_Async_ACM_Provider extends ACM_Provider {
 		switch ( $tag_id ) {
 		case 'dfp_head':
 			$ad_tags = $ad_code_manager->ad_tag_ids;
-
-			// Allow users to set targeting parameters
-			$set_targeting = apply_filters( 'acm_add_set_targets', '' );
-
 			ob_start();
 ?>
 	<!-- Include google_services.js -->

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -172,9 +172,22 @@ googletag.cmd.push(function() {
 				if ( ! empty( $matching_ad_code ) ) {
 					// @todo There might be a case when there are two tags registered with the same dimensions
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
-					// that tags are unique				
+					// that tags are unique	
+
+					/**
+					* Get unit size as array of widths x heights in case of flex spaces
+					*/
+					$unit_sizes_output = '';
+					if ( ! empty( $tt['sizes'] ) ) {
+						foreach( $tt['sizes'] as $unit_size ) {
+							$unit_sizes_output .= '[' . (int)$unit_size['width'] . ',' . (int)$unit_size['height'] . '],';
+						}
+						$unit_sizes_output = trim( $unit_sizes_output, ',' );
+					} else { // fallback for old style width x height
+						$unit_sizes_output = (int)$tt['width'] . ',' . (int)$tt['height'];
+					}
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes_output; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -177,9 +177,14 @@ googletag.cmd.push(function() {
 			/**
 			 * Get extra parameters for targeting through DFP
 			 */
-			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
+			$title_targeting = ".setTargeting('title','" . esc_js( get_the_title( $post_id ) ) . "')";
 			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
-			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
+			$fullpath_targeting = ".setTargeting('fullPath','" . get_option( 'siteurl' ) . $_SERVER['REQUEST_URI'] . "')";
+			$domain_parts = parse_url( get_option( 'siteurl' ) );
+			$domain_name = $domain_parts['host'];
+			$domain_targeting = ".setTargeting('domainName','" . $domain_name . "')";
+
+			$targeting_string = $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting . $domain_targeting;
 
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
@@ -192,7 +197,7 @@ googletag.cmd.push(function() {
 					// and the same tag id ( which is just a div id ). This confuses DFP Async, so we need to make sure
 					// that tags are unique				
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $keyword_targeting . $title_targeting . $paths_targeting . $fullpath_targeting ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo (int)$tt['width'] ?>, <?php echo (int)$tt['height'] ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $targeting_string; ?>;
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -168,11 +168,11 @@ googletag.cmd.push(function() {
 				global $wp_query;
 				$post_id = $wp_query->post->ID;
 				$args = array( 'fields' => 'names' );
-				$post_tags = wp_get_post_tags( $post_id, $args );
-				$post_tags = implode( "','", $post_tags );
-				$post_categories = wp_get_post_categories( $post_id, $args );
-				$post_categories = implode( "','", $post_categories );
-				$keyword_targeting = ".setTargeting('kw',['$post_tags','$post_categories'])";
+				$post_tags = wp_get_post_tags( $post_id, $args ); // get tag names
+				$post_categories = wp_get_post_categories( $post_id, $args ); // get category names
+				$post_keywords_arr = array_unique( array_merge( $post_tags, $post_categories ) ); // remove dupes and merge
+				$post_keywords = implode( "','", $post_keywords_arr ); // make keyword list for JS
+				$keyword_targeting = ".setTargeting('kw',['$post_keywords'])";
 			}
 			/**
 			 * Get extra parameters for targeting through DFP

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -174,7 +174,7 @@ googletag.cmd.push(function() {
 					$unit_sizes = $ad_code_manager->parse_ad_tag_sizes( $tt );
 
 ?>
-googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads())<?php echo $set_targeting; ?>;
+googletag.defineSlot('/<?php echo esc_attr( $matching_ad_code['url_vars']['dfp_id'] ); ?>/<?php echo esc_attr( $matching_ad_code['url_vars']['tag_name'] ); ?>', [<?php echo $unit_sizes; ?>], "acm-ad-tag-<?php echo esc_attr( $matching_ad_code['url_vars']['tag_id'] ); ?>").addService(googletag.pubads());
 <?php
 				}
 			endforeach;

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -169,8 +169,10 @@ googletag.cmd.push(function() {
 				$post_id = $wp_query->post->ID;
 				$args = array( 'fields' => 'names' );
 				$post_tags = wp_get_post_tags( $post_id, $args );
-				$post_tags = "['" . implode( "','", $post_tags ) . "']";
-				$keyword_targeting = ".setTargeting('kw',$post_tags)";
+				$post_tags = implode( "','", $post_tags );
+				$post_categories = wp_get_post_categories( $post_id, $args );
+				$post_categories = implode( "','", $post_categories );
+				$keyword_targeting = ".setTargeting('kw',['$post_tags','$post_categories'])";
 			}
 			/**
 			 * Get extra parameters for targeting through DFP
@@ -178,7 +180,7 @@ googletag.cmd.push(function() {
 			$title_targeting = ".setTargeting('title','" . get_the_title( $post_id ) . "')";
 			$paths_targeting = ".setTargeting('targetPaths','" . $_SERVER['REQUEST_URI'] . "')";
 			$fullpath_targeting = ".setTargeting('fullPath','" . get_option('siteurl') . $_SERVER['REQUEST_URI'] . "')";
-				
+
 			foreach ( (array) $ad_tags as $tag ):
 				if ( $tag['tag'] == 'dfp_head' )
 					continue;


### PR DESCRIPTION
I've added the option to define your ad unit sizes as an array of sizes to account for flex units. A situation where this would be important is if someone is trying to run both 728x90 and 970x66 sized units through the same header ad unit. (Or 300x250 and 300x600 ads through the same above the fold right rail unit.)

To define such an ad unit, you add a 'sizes' key to the url_vars array in the acmx_filter_ad_tag_ids ( $ids ) filter/array.

An example of how to define a flex space:
```php
array(
	        'tag'       => 'dfp_desktop_top',
	        'url_vars'  => array(
	            'tag'       => 'dfp_desktop_top',
	            'sizes'	=> array(
	            	array(
	            		'width'		=>	'728',
	            		'height'	=> '90'
	            	),
	            	array(
	            		'width'		=>	'970',
	            		'height'	=> '66'
	            	),
	            ),
	        ),
	        'enable_ui_mapping' => true
	    ),
```

This will create an ad slot that looks like:
`googletag.defineSlot('/XXX/728x90_flex', [[728,90],[970,66]], "div-id").addService(googletag.pubads())`

This update accounts for single-sized configurations as well and thus is backwards compatible with the current async tag ids array.