### PR TITLE
Change not "trick" on lines 945-949

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -943,7 +943,7 @@ class Ad_Code_Manager {
 				}
 
 				// Special trick: include '!' in front of the function name to reverse the result
-				if ( 4 === strpos( $cond_func, 'not_' ) ) {
+				if ( 0 === strpos( $cond_func, 'not_' ) ) {
 					$cond_func = ltrim( $cond_func, 'not_' );
 					$cond_result = false;
 				}

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -943,8 +943,8 @@ class Ad_Code_Manager {
 				}
 
 				// Special trick: include '!' in front of the function name to reverse the result
-				if ( 0 === strpos( $cond_func, '!' ) ) {
-					$cond_func = ltrim( $cond_func, '!' );
+				if ( 4 === strpos( $cond_func, 'not_' ) ) {
+					$cond_func = ltrim( $cond_func, 'not_' );
 					$cond_result = false;
 				}
 


### PR DESCRIPTION
On lines 945-949, there's a "special trick" to allow conditionals to be notted with a ! in front of the function name. For instance, it should allow you to do !is_home to display an ad unit on every page other than home.

However, in the Tools->ACM dashboard panel, selecting a !is_home conditional will not save, instead reverting back to is_home.

I propose changing the not trick to use not_ in front of the conditional. This way, it allows you to actually set a not conditional without having to change the save sanitation logic. As an added bonus, the select box displays "Not is home" instead of "!is home", which is easier on the eyes.