### PR TITLE
Use a filter for get_columns() so providers can add their own columns

### DIFF
--- a/common/lib/acm-wp-list-table.php
+++ b/common/lib/acm-wp-list-table.php
@@ -24,16 +24,15 @@ class ACM_WP_List_Table extends WP_List_Table {
 	 *
 	 * @return array $columns, the array of columns to use with the table
 	 */
-	function get_columns( $columns = false ) {
-		$default = array(
+	function get_columns() {
+		$columns = apply_filters( 'acm_list_table_columns', array(
 			'cb'             => '<input type="checkbox" />',
 			'id'             => __( 'ID', 'ad-code-manager' ),
 			'name'           => __( 'Name', 'ad-code-manager' ),
 			'priority'       => __( 'Priority', 'ad-code-manager' ),
 			'operator'       => __( 'Logical Operator', 'ad-code-manager' ),
 			'conditionals'   => __( 'Conditionals', 'ad-code-manager' ),
-		);
-		$columns = apply_filters( 'acm_list_table_columns', !is_array( $columns ) || empty( $columns ) ? $default : $columns );
+		) );
 		// Fail-safe for misconfiguration
 		$required_before = array(
 			'id'             => __( 'ID', 'ad-code-manager' ),

--- a/providers/doubleclick-for-publishers-async.php
+++ b/providers/doubleclick-for-publishers-async.php
@@ -215,12 +215,11 @@ class Doubleclick_For_Publishers_Async_ACM_WP_List_Table extends ACM_WP_List_Tab
 			) );
 	}
 
-
 	/**
-	 * This is nuts and bolts of table representation
+	 * @return array The columns that shall be used
 	 */
-	function get_columns( $columns = null ) {
-		$columns = array(
+	function filter_columns() {
+		return array(
 			'cb'             => '<input type="checkbox" />',
 			'id'             => __( 'ID', 'ad-code-manager' ),
 			'tag'            => __( 'Tag', 'ad-code-manager' ),
@@ -231,7 +230,14 @@ class Doubleclick_For_Publishers_Async_ACM_WP_List_Table extends ACM_WP_List_Tab
 			'operator'       => __( 'Logical Operator', 'ad-code-manager' ),
 			'conditionals'   => __( 'Conditionals', 'ad-code-manager' ),
 		);
-		return parent::get_columns( $columns );
+	}
+
+	/**
+	 * This is nuts and bolts of table representation
+	 */
+	function get_columns() {
+		add_filter( 'acm_list_table_columns', array( $this, 'filter_columns' ) );
+		return parent::get_columns();
 	}
 
 	/**

--- a/providers/doubleclick-for-publishers.php
+++ b/providers/doubleclick-for-publishers.php
@@ -93,12 +93,11 @@ class Doubleclick_For_Publishers_ACM_WP_List_Table extends ACM_WP_List_Table {
 			) );
 	}
 
-
 	/**
-	 * This is nuts and bolts of table representation
+	 * @return array The columns that shall be used
 	 */
-	function get_columns( $columns = null ) {
-		$columns = array(
+	function filter_columns() {
+		return array(
 			'cb'             => '<input type="checkbox" />',
 			'id'             => __( 'ID', 'ad-code-manager' ),
 			'site_name'      => __( 'Site Name', 'ad-code-manager' ),
@@ -107,7 +106,14 @@ class Doubleclick_For_Publishers_ACM_WP_List_Table extends ACM_WP_List_Table {
 			'operator'       => __( 'Logical Operator', 'ad-code-manager' ),
 			'conditionals'   => __( 'Conditionals', 'ad-code-manager' ),
 		);
-		return parent::get_columns( $columns );
+	}
+
+	/**
+	 * This is nuts and bolts of table representation
+	 */
+	function get_columns() {
+		add_filter( 'acm_list_table_columns', array( $this, 'filter_columns' ) );
+		return parent::get_columns();
 	}
 
 	/**

--- a/providers/google-adsense.php
+++ b/providers/google-adsense.php
@@ -161,10 +161,10 @@ class Google_AdSense_ACM_WP_List_Table extends ACM_WP_List_Table {
 	}
 
 	/**
-	 * This is nuts and bolts of table representation
+	 * @return array The columns that shall be used
 	 */
-	function get_columns( $columns = null ) {
-		$columns = array(
+	function filter_columns() {
+		return array(
 			'cb'             => '<input type="checkbox" />',
 			'id'             => __( 'ID', 'ad-code-manager' ),
 			'tag'            => __( 'Tag', 'ad-code-manager' ),
@@ -174,7 +174,14 @@ class Google_AdSense_ACM_WP_List_Table extends ACM_WP_List_Table {
 			'operator'       => __( 'Logical Operator', 'ad-code-manager' ),
 			'conditionals'   => __( 'Conditionals', 'ad-code-manager' ),
 		);
-		return parent::get_columns( $columns );
+	}
+
+	/**
+	 * This is nuts and bolts of table representation
+	 */
+	function get_columns() {
+		add_filter( 'acm_list_table_columns', array( $this, 'filter_columns' ) );
+		return parent::get_columns();
 	}
 
 	/**


### PR DESCRIPTION
This prevents a strict standards error because the `get_columns()` method of `WP_List_Table` class doesn't accept any params. Fixes #90.