### PR TITLE
Prevent Array to String errors

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -1037,7 +1037,9 @@ class Ad_Code_Manager {
 
 		foreach ( $code_to_display['url_vars'] as $url_var => $val ) {
 			$new_key = '%' . $url_var . '%';
-			$output_tokens[$new_key] = $val;
+			if ( is_string( $val ) ) {
+				$output_tokens[$new_key] = $val;
+			}
 		}
 
 		return $output_tokens;


### PR DESCRIPTION
Simple check to make sure we are assigning a string to `$output_tokens[$new_key]` as sometimes its not and create Array to String error.
![image](https://cloud.githubusercontent.com/assets/1457540/8607834/b7e601cc-264a-11e5-9852-423175fa57f2.png)
