### PR TITLE
PHP 7 Compatibility Changes

### DIFF
--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -118,10 +118,6 @@ class Markdown_Parser {
 		asort( $this->span_gamut );
 	}
 
-	function Markdown_Parser() {
-		self::__construct();
-	}
-
 	// Internal hashes used during transformation.
 	var $urls = array();
 	var $titles = array();
@@ -1575,10 +1571,6 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		);
 
 		parent::Markdown_Parser();
-	}
-
-	function MarkdownExtra_Parser() {
-		self::__construct();
 	}
 
 	// Extra variables used during extra transformations.

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -95,7 +95,7 @@ class Markdown_Parser {
 	var $predef_titles = array();
 
 
-	function Markdown_Parser() {
+	function __construct() {
 		//
 		// Constructor function. Initialize appropriate member variables.
 		//
@@ -118,6 +118,9 @@ class Markdown_Parser {
 		asort( $this->span_gamut );
 	}
 
+	function Markdown_Parser() {
+		self::__construct();
+	}
 
 	// Internal hashes used during transformation.
 	var $urls = array();
@@ -1545,7 +1548,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	var $predef_abbr = array();
 
 
-	function MarkdownExtra_Parser() {
+	function __construct() {
 		//
 		// Constructor function. Initialize the parser object.
 		//
@@ -1574,6 +1577,9 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		parent::Markdown_Parser();
 	}
 
+	function MarkdownExtra_Parser() {
+		self::__construct();
+	}
 
 	// Extra variables used during extra transformations.
 	var $footnotes = array();


### PR DESCRIPTION
Replacing PHP4 style constructors to ensure PHP7 compatibility.
