### PR TITLE
Call parent constructor in PHP 7 compatible way

### DIFF
--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1570,7 +1570,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			"doAbbreviations"    => 70,
 		);
 
-		parent::Markdown_Parser();
+		parent::__construct();
 	}
 
 	// Extra variables used during extra transformations.


### PR DESCRIPTION
This prevents a fatal error on newer versions of PHP.

This is a follow-up to #103.

Fixes #105.