### PR TITLE
Replace create_function with an actual anonymous function

### DIFF
--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1503,11 +1503,11 @@ class Markdown_Parser {
 		// regular expression.
 		//
 		if ( function_exists( $this->utf8_strlen ) ) return;
-		$this->utf8_strlen = create_function( '$text', 'return preg_match_all(
-			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/",
-			$text, $m);' );
+		$this->utf8_strlen = function( $text ) {
+			return preg_match_all(
+			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", $text, $m );
+		};
 	}
-
 
 	function unhash( $text ) {
 		//


### PR DESCRIPTION
`create_function()` was deprecated in PHP 7.2.0

From the manual - 
>Given the security issues of this function (being a thin wrapper around eval()), this dated function has now been deprecated. The preferred alternative is to use anonymous functions.

