### PR TITLE
Fix PHP 7.4 warnings/notices

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -849,6 +849,11 @@ class Ad_Code_Manager {
 			return;
 
 		$code_to_display = $this->get_matching_ad_code( $tag_id );
+		
+		// get_matching_ad_code can return an empty value.
+		if ( empty( $code_to_display ) ) {
+			return;
+		}
 
 		// Run $url aganist a whitelist to make sure it's a safe URL
 		if ( !$this->validate_script_url( $code_to_display['url'] ) )

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1864,7 +1864,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 					// Increase/decrease nested tag count.
 					//
 					if ( $tag[1] == '/' )      $depth--;
-					else if ( $tag{strlen( $tag )-2} != '/' ) $depth++;
+					else if ( $tag[strlen( $tag )-2] != '/' ) $depth++;
 
 					if ( $depth < 0 ) {
 						//
@@ -1991,7 +1991,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 				//
 				if ( preg_match( '{^</?'.$base_tag_name_re.'\b}', $tag ) ) {
 					if ( $tag[1] == '/' )      $depth--;
-					else if ( $tag{strlen( $tag )-2} != '/' ) $depth++;
+					else if ( $tag[strlen( $tag )-2] != '/' ) $depth++;
 				}
 
 				//

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1785,7 +1785,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			//
 			// Check for: Code span marker
 			//
-			if ( $tag{0} == "`" ) {
+			if ( $tag[0] == "`" ) {
 				// Find corresponding end marker.
 				$tag_re = preg_quote( $tag );
 				if ( preg_match( '{^(?>.+?|\n(?!\n))*?(?<!`)'.$tag_re.'(?!`)}',
@@ -1819,7 +1819,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			//
 			// Check for: Indented code block.
 			//
-			else if ( $tag{0} == "\n" || $tag{0} == " " ) {
+			else if ( $tag[0] == "\n" || $tag[0] == " " ) {
 				// Indented code block: pass it unchanged, will be handled
 				// later.
 				$parsed .= $tag;
@@ -1968,7 +1968,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 				// first character as filtered to prevent an infinite loop in the
 				// parent function.
 				//
-				return array( $original_text{0}, substr( $original_text, 1 ) );
+				return array( $original_text[0], substr( $original_text, 1 ) );
 			}
 
 			$block_text .= $parts[0]; // Text before current tag.
@@ -2114,7 +2114,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	function _doHeaders_callback_setext( $matches ) {
 		if ( $matches[3] == '-' && preg_match( '{^- }', $matches[1] ) )
 			return $matches[0];
-		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$level = $matches[3][0] == '=' ? 1 : 2;
 		$attr  = $this->_doHeaders_attr( $id =& $matches[2] );
 		$block = "<h$level$attr>".$this->runSpanGamut( $matches[1] )."</h$level>";
 		return "\n" . $this->hashBlock( $block ) . "\n\n";

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1437,7 +1437,7 @@ class Markdown_Parser {
 		//
 		switch ( $token[0] ) {
 		case "\\":
-			return $this->hashPart( "&#". ord($token[1]). ";" );
+			return $this->hashPart( "&#". ord( $token[1] ). ";" );
 		case "`":
 			// Search for end marker in remaining text.
 			if ( preg_match( '/^(.*?[^`])'.preg_quote( $token ).'(?!`)(.*)$/sm',
@@ -1503,7 +1503,7 @@ class Markdown_Parser {
 		// regular expression.
 		//
 		if ( function_exists( $this->utf8_strlen ) ) return;
-		$this->utf8_strlen = function ( $text ) {
+		$this->utf8_strlen = function( $text ) {
 			return preg_match_all(
 				"/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/",
 				$text, $m

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1846,7 +1846,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			//            HTML Comments, processing instructions.
 			//
 			else if ( preg_match( '{^<(?:'.$this->clean_tags_re.')\b}', $tag ) ||
-					$tag{1} == '!' || $tag{1} == '?' ) {
+					$tag[1] == '!' || $tag[1] == '?' ) {
 				// Need to parse tag and following text using the HTML parser.
 				// (don't check for markdown attribute)
 				list( $block_text, $text ) =
@@ -1863,7 +1863,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 					//
 					// Increase/decrease nested tag count.
 					//
-					if ( $tag{1} == '/' )      $depth--;
+					if ( $tag[1] == '/' )      $depth--;
 					else if ( $tag{strlen( $tag )-2} != '/' ) $depth++;
 
 					if ( $depth < 0 ) {
@@ -1980,7 +1980,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			//    Comments and Processing Instructions.
 			//
 			if ( preg_match( '{^</?(?:'.$this->auto_close_tags_re.')\b}', $tag ) ||
-				$tag{1} == '!' || $tag{1} == '?' ) {
+				$tag[1] == '!' || $tag[1] == '?' ) {
 				// Just add the tag to the block as if it was text.
 				$block_text .= $tag;
 			}
@@ -1990,7 +1990,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 				// the tag's name match base tag's.
 				//
 				if ( preg_match( '{^</?'.$base_tag_name_re.'\b}', $tag ) ) {
-					if ( $tag{1} == '/' )      $depth--;
+					if ( $tag[1] == '/' )      $depth--;
 					else if ( $tag{strlen( $tag )-2} != '/' ) $depth++;
 				}
 

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -786,7 +786,7 @@ class Markdown_Parser {
 		if ( $matches[2] == '-' && preg_match( '{^-(?: |$)}', $matches[1] ) )
 			return $matches[0];
 
-		$level = $matches[2]{0} == '=' ? 1 : 2;
+		$level = $matches[2][0] == '=' ? 1 : 2;
 		$block = "<h$level>".$this->runSpanGamut( $matches[1] )."</h$level>";
 		return "\n" . $this->hashBlock( $block ) . "\n\n";
 	}
@@ -1081,7 +1081,7 @@ class Markdown_Parser {
 				} else {
 					// Other closing marker: close one em or strong and
 					// change current token state to match the other
-					$token_stack[0] = str_repeat( $token{0}, 3-$token_len );
+					$token_stack[0] = str_repeat($token[0], 3-$token_len);
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut( $span );
@@ -1106,7 +1106,7 @@ class Markdown_Parser {
 					} else {
 						// Reached opening three-char emphasis marker. Push on token
 						// stack; will be handled by the special condition above.
-						$em = $token{0};
+						$em = $token[0];
 						$strong = "$em$em";
 						array_unshift( $token_stack, $token );
 						array_unshift( $text_stack, '' );
@@ -1435,9 +1435,9 @@ class Markdown_Parser {
 		// Handle $token provided by parseSpan by determining its nature and
 		// returning the corresponding value that should replace it.
 		//
-		switch ( $token{0} ) {
+		switch ($token[0]) {
 		case "\\":
-			return $this->hashPart( "&#". ord( $token{1} ). ";" );
+			return $this->hashPart("&#". ord($token[1]). ";");
 		case "`":
 			// Search for end marker in remaining text.
 			if ( preg_match( '/^(.*?[^`])'.preg_quote( $token ).'(?!`)(.*)$/sm',
@@ -1503,11 +1503,14 @@ class Markdown_Parser {
 		// regular expression.
 		//
 		if ( function_exists( $this->utf8_strlen ) ) return;
-		$this->utf8_strlen = function( $text ) {
+		$this->utf8_strlen = function ($text) {
 			return preg_match_all(
-			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", $text, $m );
+				"/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/",
+				$text, $m
+			);
 		};
 	}
+
 
 	function unhash( $text ) {
 		//

--- a/common/lib/markdown.php
+++ b/common/lib/markdown.php
@@ -1081,7 +1081,7 @@ class Markdown_Parser {
 				} else {
 					// Other closing marker: close one em or strong and
 					// change current token state to match the other
-					$token_stack[0] = str_repeat($token[0], 3-$token_len);
+					$token_stack[0] = str_repeat( $token[0], 3-$token_len );
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut( $span );
@@ -1435,9 +1435,9 @@ class Markdown_Parser {
 		// Handle $token provided by parseSpan by determining its nature and
 		// returning the corresponding value that should replace it.
 		//
-		switch ($token[0]) {
+		switch ( $token[0] ) {
 		case "\\":
-			return $this->hashPart("&#". ord($token[1]). ";");
+			return $this->hashPart( "&#". ord($token[1]). ";" );
 		case "`":
 			// Search for end marker in remaining text.
 			if ( preg_match( '/^(.*?[^`])'.preg_quote( $token ).'(?!`)(.*)$/sm',
@@ -1503,7 +1503,7 @@ class Markdown_Parser {
 		// regular expression.
 		//
 		if ( function_exists( $this->utf8_strlen ) ) return;
-		$this->utf8_strlen = function ($text) {
+		$this->utf8_strlen = function ( $text ) {
 			return preg_match_all(
 				"/[\\x00-\\xBF]|[\\xC0-\\xFF][\\x80-\\xBF]*/",
 				$text, $m


### PR DESCRIPTION
I made the same changes to this file that were made in the WordPress.org plugin directory's version. See [this Trac ticket](https://meta.trac.wordpress.org/ticket/5363). Then I corrected a few additional instances of curly syntax because WordPress.org's version of this class is newer. This all seems to work nicely. My ads still load, and the warning/notices no longer appear in my logs while running PHP 7.4. If merged, this fixes #112.

It's not clear to me if this plugin has been abandoned, so it doesn't seem like the time to upgrade the Markdown parser itself.