### PR TITLE
Composer: Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,21 @@
 	],
 	"require": {
 		"php": ">=5.6",
-		"composer/installers": "~1.0"
+		"composer/installers": "^1.0 | ^2.0"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^2.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
-		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/phpunit-polyfills": "^0.2.0"
+		"yoast/wp-test-utils": "^1"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"scripts": {
 		"cbf": [


### PR DESCRIPTION
- Add `allow-plugins` configuration for the two Composer plugins, in advance of the July 2022 requirement.
- Switch from `yoast/phpunit-polyfills` to `yoast/wp-test-utils` which includes a newer version of PHPUnit Polyfills and some other bits useful for running WP / integration tests.
- Remove PHPCS and PHPUnit direct dependencies as they are included via other direct dependencies.