### PR TITLE
Tests: Remove PHP 8.2 check

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -40,10 +40,6 @@ jobs:
             wordpress: '5.8.3'
             experimental: false
             coverage: none
-#          - php: '8.2'
-#            wordpress: 'trunk'
-#            experimental: true
-#            coverage: none
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
It is known that tests will fail as WP core is not yet compatible, so it's not even worth testing this.