### PR TITLE
Change how main plugin class is initialized

### DIFF
--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -1,29 +1,33 @@
 <?php
-/*
-Plugin Name: Ad Code Manager
-Plugin URI: http://automattic.com
-Description: Easy ad code management
-Author: Rinat Khaziev, Jeremy Felt, Daniel Bachhuber, Automattic, doejo
-Version: 0.5
-Author URI: http://automattic.com
+/**
+ * Ad Code Manager
+ *
+ * @package      Automattic\AdCodeManager
+ * @author       Automattic and contributors
+ * @copyright    2012 and later, Automattic and contributors
+ * @license      GPL-2.0-or-later
+ *
+ * @wordpress-plugin
+ * Plugin Name:       Ad Code Manager
+ * Plugin URI:        https://wordpress.org/plugins/ad-code-manager/
+ * Description:       Easy ad code management.
+ * Version:           0.5.0
+ * Author:            Automattic and contributors
+ * Author URI:        https://github.com/Automattic/ad-code-manager/graphs/contributors
+ * Text Domain:       ad-code-manager
+ * License:           GPL-2.0-or-later
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * GitHub Plugin URI: https://github.com/Automattic/ad-code-manager/
+ * Requires PHP:      7.1
+ * Requires WP:       5.5.0
+ */
 
-GNU General Public License, Free Software Foundation <http://creativecommons.org/licenses/GPL/2.0/>
+declare(strict_types=1);
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
+namespace Automattic\AdCodeManager;
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+use Ad_Code_Manager;
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
-*/
 const AD_CODE_MANAGER_VERSION = '0.5';
 const AD_CODE_MANAGER_FILE    = __FILE__;
 

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -33,5 +33,7 @@ require_once __DIR__ . '/src/class-acm-widget.php';
 require_once __DIR__ . '/src/markdown.php';
 require_once __DIR__ . '/src/class-ad-code-manager.php';
 
-global $ad_code_manager;
-$ad_code_manager = new Ad_Code_Manager();
+add_action( 'plugins_loaded', function () {
+	$GLOBALS['ad_code_manager'] = new Ad_Code_Manager();
+	$GLOBALS['ad_code_manager']->run();
+} );

--- a/src/class-ad-code-manager.php
+++ b/src/class-ad-code-manager.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 //namespace Automattic\AdCodeManager;
 
+use const Automattic\AdCodeManager\AD_CODE_MANAGER_FILE;
+use const Automattic\AdCodeManager\AD_CODE_MANAGER_VERSION;
+
 class Ad_Code_Manager {
 
 	public $ad_codes = array();

--- a/src/class-ad-code-manager.php
+++ b/src/class-ad-code-manager.php
@@ -31,7 +31,7 @@ class Ad_Code_Manager {
 	 *
 	 * @since 0.1
 	 */
-	function __construct() {
+	function run() {
 		add_action( 'init', array( $this, 'action_load_providers' ) );
 		add_action( 'init', array( $this, 'action_init' ) );
 

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -50,7 +50,7 @@ namespace Automattic\AdCodeManager\Tests\Integration {
 }
 
 // Plugin root file is not included during tests, so define the namespaced constants here.
-namespace Parsely {
-	const PARSELY_VERSION = '123456.78.9';
-	const PARSELY_FILE    = __DIR__ . '/../../wp-parsely.php';
+namespace Automattic\AdCodeManager {
+	const AD_CODE_MANAGER_VERSION = '123456.78.9';
+	const AD_CODE_MANAGER_FILE    = __DIR__ . '/../../ad-code-manager.php';
 }


### PR DESCRIPTION
- Rename the constructor to `run()`, as it wasn't constructing the object, but integrating with WordPress through `add_*()` calls. This makes the class more testable.
- Wrap the instantiation and call to `run()` in a plugins_loaded callback, to allow others to have their code called first.