### PR TITLE
Check post type of the received post ID before deletion

### DIFF
--- a/src/class-ad-code-manager.php
+++ b/src/class-ad-code-manager.php
@@ -524,7 +524,7 @@ class Ad_Code_Manager {
 	 * Delete an existing ad code
 	 */
 	function delete_ad_code( $ad_code_id ) {
-		if ( 0 !== $ad_code_id ) {
+		if ( 0 !== $ad_code_id && $this->post_type === get_post_type( $ad_code_id ) ) {
 			wp_delete_post( $ad_code_id , true ); // Force delete post.
 			$this->flush_cache();
 			return true;

--- a/tests/Integration/AdCodeManagerTest.php
+++ b/tests/Integration/AdCodeManagerTest.php
@@ -42,6 +42,17 @@ class AdCodeManagerTest extends TestCase {
 		self::assertIsInt( $this->acm->edit_ad_code( 555,  $this->mock_ad_code() ) );
 	}
 
+	public function test_deleting_ad_requires_correct_post_type() {
+		$ad_id   = $this->create_ad_code_and_return();
+		$post_id = self::factory()->post->create();
+
+		// Can delete the ad ID, because it is an ID with the correct custom post type.
+		self::assertTrue( $this->acm->delete_ad_code( $ad_id ) );
+
+		// Can't delete the general post ID, because it is not an ad post type.
+		self::assertNull( $this->acm->delete_ad_code( $post_id ) );
+	}
+
 	private function mock_ad_code() {
 		$ad_code = array();
 		foreach ( $this->acm->current_provider->ad_code_args as $arg ) {


### PR DESCRIPTION
Validate that the post type of the received post ID matches `acm-code` before attempting a deletion to prevent deleting other types of posts.

This function gets called when deleting a single ad code or doing a bulk deletion.