### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Exclude these files from release archives.
+
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+
+# If you develop for this package using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+
+# They are also used when pushing to WordPress.org SVN using the
+# https://github.com/10up/action-wordpress-plugin-deploy GitHub Action.
+
+# Directories
+/.github                         export-ignore
+/.wordpress-org                  export-ignore
+/bin                             export-ignore
+/tests                           export-ignore
+
+# Files
+/.editorconfig                   export-ignore
+/.gitattributes                  export-ignore
+/.gitignore                      export-ignore
+/.phpcs.xml.dist                 export-ignore
+/CHANGELOG.md                    export-ignore
+/composer.json                   export-ignore
+/phpunit.xml.dist                export-ignore


### PR DESCRIPTION
Exclude these files from release archives.

This will also make them unavailable when using Composer with `--prefer-dist`.

They are also used when pushing to WordPress.org SVN using the https://github.com/10up/action-wordpress-plugin-deploy GitHub Action.