### PR TITLE
Fix untranslatable strings in PHP

### DIFF
--- a/src/class-ad-code-manager.php
+++ b/src/class-ad-code-manager.php
@@ -17,11 +17,9 @@ class Ad_Code_Manager {
 
 	public $ad_codes                 = array();
 	public $whitelisted_conditionals = array();
-	public $title                    = 'Ad Code Manager';
 	public $post_type                = 'acm-code';
 	public $plugin_slug              = 'ad-code-manager';
 	public $manage_ads_cap           = 'manage_options';
-	public $post_type_labels;
 	public $logical_operator;
 	public $ad_tag_ids;
 	public $providers;
@@ -129,13 +127,6 @@ class Ad_Code_Manager {
 	 * @since 0.1
 	 */
 	function action_init() {
-		load_plugin_textdomain( 'ad-code-manager', false, plugin_basename( dirname( __FILE__ ) ) . '/languages/' );
-
-		$this->post_type_labels = array(
-			'name'          => __( 'Ad Codes', 'ad-code-manager' ),
-			'singular_name' => __( 'Ad Code', 'ad-code-manager' ),
-		);
-
 		// Allow other conditionals to be used
 		$this->whitelisted_conditionals = array(
 			'is_home',
@@ -192,14 +183,17 @@ class Ad_Code_Manager {
 	 * @since 0.1
 	 */
 	function register_acm_post_type() {
-		register_post_type(
-			$this->post_type,
-			array(
-				'labels'  => $this->post_type_labels,
+		$labels = array(
+			'name'          => _x( 'Ad Codes', 'Post Type General Name', 'ad-code-manager' ),
+			'singular_name' => _x( 'Ad Code', 'Post Type Singular Name', 'ad-code-manager' ),
+		);
+		$args = array(
+				'labels'  => $labels,
 				'public'  => false,
 				'rewrite' => false,
-			)
 		);
+
+		register_post_type( $this->post_type, $args );
 	}
 
 	/**
@@ -587,7 +581,13 @@ class Ad_Code_Manager {
 	 * Hook in our submenu page to the navigation
 	 */
 	public function action_admin_menu() {
-		$hook = add_submenu_page( 'tools.php', $this->title, $this->title, $this->manage_ads_cap, $this->plugin_slug, array( $this, 'admin_view_controller' ) );
+		$hook = add_management_page(
+				__( 'Ad Code Manager', 'ad-code-manager' ),
+				__( 'Ad Code Manager', 'ad-code-manager' ),
+				$this->manage_ads_cap,
+				$this->plugin_slug,
+				array( $this, 'admin_view_controller' )
+		);
 		add_action( 'load-' . $hook, array( $this, 'action_load_ad_code_manager' ) );
 	}
 

--- a/views/ad-code-manager.tpl.php
+++ b/views/ad-code-manager.tpl.php
@@ -4,8 +4,8 @@
  */
 ?>
 	<div class="acm-ui-wrapper wrap">
-	<h2>Ad Code Manager</h2>
-	<?php 
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+	<?php
 	if ( isset( $_REQUEST['message'] ) ) {
 		switch ( $_REQUEST['message'] ) {
 			case 'ad-code-added':
@@ -24,12 +24,12 @@
 				$message_text = '';
 				break;
 		}
-		if ( $message_text ) {
+		if ( '' !== $message_text ) {
 			echo '<div class="message updated"><p>' . esc_html( $message_text ) . '</p></div>';
 		}
-	} 
+	}
 	?>
-	<p> Refer to help section for more information</p>
+	<p><?php esc_html_e( 'Refer to help section for more information.', 'ad-code-manager' ); ?></p>
 	</div>
 
 <div class="wrap nosubsub">
@@ -55,23 +55,19 @@ $this->wp_list_table->display();
 <div class="form-wrap">
 <?php
 // Only show the provider selector if one hasn't been specified at the code level.
-if ( ! apply_filters( 'acm_provider_slug', false ) ) : 
+if ( ! apply_filters( 'acm_provider_slug', false ) ) :
 	?>
 <div class="acm-global-options">
-	<h3><?php _e( 'Configuration', 'ad-code-manager' ); ?></h3>
+	<h2><?php esc_html_e( 'Configuration', 'ad-code-manager' ); ?></h2>
 	<div class="form-wrap">
 	<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" name="updatesettings" id="updatesettings">
 	<div id="provider-field" class="form-field form-required">
-		<label for="provider"><?php _e( 'Select a provider:', 'ad-code-manager' ); ?></label>
+		<label for="provider"><?php esc_html_e( 'Select a provider:', 'ad-code-manager' ); ?></label>
 		<select name="provider" id="provider">
-		<?php 
+		<?php
 		$current_provider = $this->get_option( 'provider' );
 		foreach ( $this->providers as $slug => $provider ) :
-			if ( isset( $provider['label'] ) ) {
-				$label = $provider['label'];
-			} else {
-				$label = ucwords( str_replace( '_', ' ', $slug ) );
-			}
+			$label = $provider['label'] ?? ucwords( str_replace( '_', ' ', $slug ) );
 			?>
 			<option value="<?php echo esc_attr( $slug ); ?>" <?php selected( $slug, $current_provider ); ?>><?php echo esc_html( $label ); ?></option>
 		<?php endforeach; ?>
@@ -86,7 +82,7 @@ if ( ! apply_filters( 'acm_provider_slug', false ) ) :
 	</div>
 </div>
 <?php endif; ?>
-<h3><?php _e( 'Add New Ad Code', 'ad-code-manager' ); ?></h3>
+<h2><?php esc_html_e( 'Add New Ad Code', 'ad-code-manager' ); ?></h2>
 <form id="add-adcode" method="POST" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" class="validate">
 <input type="hidden" name="action" value="acm_admin_action" />
 <input type="hidden" name="method" value="add" />
@@ -129,11 +125,11 @@ endforeach;
 ?>
 <div class="form-field acm-conditional-fields" id="conditional-tpl">
 	<div class="form-new-row">
-	<label for="acm-conditionals"><?php _e( 'Conditionals', 'ad-code-manager' ); ?></label>
+	<label for="acm-conditionals"><?php esc_html_e( 'Conditionals', 'ad-code-manager' ); ?></label>
 	<div class="conditional-single-field" id="conditional-single-field-master">
 	<div class="conditional-function">
 	<select name="acm-conditionals[]">
-<option value=""><?php _e( 'Select conditional', 'ad-code-manager' ); ?></option>
+<option value=""><?php esc_html_e( 'Select conditional', 'ad-code-manager' ); ?></option>
 <?php
 foreach ( $this->whitelisted_conditionals as $key ) :
 	?>
@@ -147,7 +143,7 @@ foreach ( $this->whitelisted_conditionals as $key ) :
 	</div>
 </div>
 <div class="form-field form-add-more">
-	<a href="#" class="button button-secondary add-more-conditionals">Add more</a>
+	<a href="#" class="button button-secondary add-more-conditionals"><?php esc_html_e( 'Add more', 'ad-code-manager' ); ?></a>
 </div>
 </div>
 <p class="clear"></p>


### PR DESCRIPTION
- Adds some escaping to some strings in the UI.
- Makes some strings translatable.
- Cleans up the labels for registering the post type.
- Removes `load_plugin_textdomain()` call as the plugin requires more than WP 4.6.

Doesn't fix the strings added via JavaScript as that needs more thought.

Closes #129