### PR TITLE
Deploy: Remove broken NPM caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Configure NPM cache
-        uses: c-hive/gha-npm-cache@v1
-
       - name: Install Dependencies
         run: npm install
 


### PR DESCRIPTION
Requires a `package-lock.json` file, but this is gitignored. Caching likely isn't needed for this occasional workflow anyway.