### PR TITLE
Composer: Update to VIPCS 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,9 @@
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "^2.2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+		"automattic/vipwpcs": "^3",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"wp-coding-standards/wpcs": "^2.3.0",
 		"yoast/wp-test-utils": "^1"
 	},
 	"config": {


### PR DESCRIPTION
Closes #162.

The codebase already had a lot of CS violations that need addressing, and this hasn't changed with the VIPCS (and WordPressCS) version increase.