### PR TITLE
Increase minimum WP and PHP supported versions

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -21,10 +21,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.1', '8.1']
+        php: ['7.4', '8.2']
         experimental: [false]
         include:
-          - php: '8.2'
+          - php: '8.3'
             experimental: true
       fail-fast: false
 
@@ -54,14 +54,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
-        if: ${{ matrix.php < 8.2 }}
         uses: ramsey/composer-install@v2
-
-      - name: Install Composer dependencies for PHP >= 8.2
-        if: ${{ matrix.php >= 8.2 }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-reqs
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -70,7 +63,7 @@ jobs:
       # Needed as runs-on: system doesn't have xml-lint by default.
       # @link https://github.com/marketplace/actions/xml-lint
       - name: Lint phpunit.xml.dist
-        if: ${{ matrix.php >= 7.3 }}
+        if: ${{ matrix.php >= 8.0 }}
         uses: ChristophWurst/xmllint-action@v1
         with:
           xml-file: ./phpunit.xml.dist

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -84,4 +84,17 @@ jobs:
         run: composer prepare-ci --no-interaction
 
       - name: Run integration tests
+        if: ${{ matrix.coverage == false }}
         run: composer test --no-interaction
+
+      - name: Run integration tests with code coverage
+        if: ${{ matrix.coverage == true  }}
+        run: composer coverage-ci --no-interaction
+
+      - name: Send coverage report to Codecov
+        if: ${{ success() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -11,37 +11,49 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}
 
     strategy:
-      # PHP 7.1 uses PHPUnit 7.5.20
-      # PHP 7.2 uses PHPUnit 8.5.21
-      # PHP 7.3 uses PHPUnit 9.5.10
-      # PHP 7.4 uses PHPUnit 9.5.10
-      # PHP 8.0 uses PHPUnit 9.5.10
-      # PHP 8.1 uses PHPUnit 9.5.10
-      # PHP 8.2 uses PHPUnit 9.5.10
-      # Key:
-      # - coverage: Whether to run the tests with code coverage.
-      # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        wordpress: ['5.5', '5.6', '5.7', '5.8', '5.9']
-        experimental: [false]
-        coverage: [none]
+        php: [ '7.4', '8.2' ]
+        wordpress: [ '5.7', '6.3' ]
+        allowed_failure: [false]
+        coverage: [false]
         include:
-          - php: '7.1'
-            wordpress: '5.8.3'
-            experimental: false
-            coverage: none
+          # Check upcoming WP.
+          - php: '8.2'
+            wordpress: 'trunk'
+            allowed_failure: true
+            coverage: false
+          # Check upcoming PHP.
+          - php: '8.3'
+            wordpress: 'latest'
+            allowed_failure: true
+            coverage: false
+          # Code coverage on latest PHP and WP.
+          - php: '8.2'
+            wordpress: 'latest'
+            allowed_failure: false
+            coverage: true
+        exclude:
+          # WordPress 5.7 doesn't support PHP 8.2.
+          - php: '8.2'
+            wordpress: '5.7'
       fail-fast: false
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.allowed_failure }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,8 +62,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.extensions }}
-          coverage: ${{ matrix.coverage }}
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -60,14 +71,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php < 8.2 }}
         uses: ramsey/composer-install@v2
-
-      - name: Install Composer dependencies for PHP >= 8.2
-        if: ${{ matrix.php >= 8.2 }}
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: --ignore-platform-reqs
 
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.phpunit.result.cache
+/.phpunit.cache
+/clover.xml
 /composer.lock
 /package-lock.json
 /vendor

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -30,7 +30,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.1-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.5"/>
+	<config name="minimum_supported_wp_version" value="5.7"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ad Code Manager
 
 Stable tag: 0.6.0  
-Requires at least: 5.5  
+Requires at least: 5.7  
 Tested up to: 5.9  
-Requires PHP: 7.1  
+Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 Tags: advertising, ad codes, ads, adsense, dfp, doubleclick for publishers  
@@ -25,7 +25,7 @@ Once this configuration is in place, the Ad Code Manager admin interface will al
 
 ## Installation
 
-The plugin requires PHP 7.1 or later. It is also test on WordPress 5.5 and later, though it may run on older versions.
+The plugin requires PHP 7.4 or later. It is also test on WordPress 5.7 and later, though it may run on older versions.
 
 Since the plugin is in its early stages, there are a couple additional configuration steps:
 

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -18,8 +18,8 @@
  * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/ad-code-manager/
- * Requires PHP:      7.1
- * Requires WP:       5.5.0
+ * Requires PHP:      7.4
+ * Requires WP:       5.7
  */
 
 declare(strict_types=1);

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1",
+		"php": ">=7.4",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 			"@php ./vendor/bin/phpcbf"
 		],
 		"coverage": [
-			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html"
+			"@php ./vendor/bin/phpunit --coverage-html ./.phpunit.cache/coverage-html"
 		],
 		"coverage-ci": [
 			"@php ./vendor/bin/phpunit"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-		bootstrap="./tests/Integration/bootstrap.php"
-		backupGlobals="false"
-		beStrictAboutCoversAnnotation="true"
-		beStrictAboutTestsThatDoNotTestAnything="true"
-		colors="true"
-		convertDeprecationsToExceptions="true"
-		testdox="true"
->
-	<php>
-		<server name="SERVER_PORT" value="80"/>
-		<server name="HTTP_HOST" value="localhost"/>
-		<server name="REMOTE_ADDR" value="127.0.0.1"/>
-	</php>
-	<testsuites>
-		<testsuite name="integration">
-			<directory>./tests/Integration</directory>
-		</testsuite>
-	</testsuites>
-	<coverage>
-		<include>
-			<directory suffix=".php">src</directory>
-			<file>ad-code-manager.php</file>
-		</include>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="./tests/Integration/bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+		 colors="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+		 testdox="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
 		<report>
 			<text outputFile="php://stdout"/>
+			<clover outputFile="clover.xml"/>
 		</report>
-	</coverage>
+    </coverage>
 </phpunit>

--- a/tests/Integration/UI/PluginActionsTest.php
+++ b/tests/Integration/UI/PluginActionsTest.php
@@ -22,6 +22,15 @@ final class PluginActionsTest extends TestCase {
 	 * Check that plugins screen will add a hook to change the plugin action links.
 	 *
 	 * @covers \Automattic\AdCodeManager\UI\Plugin_Actions::run
+	 * @uses ACM_Provider::__construct
+	 * @uses Ad_Code_Manager::action_init
+	 * @uses Ad_Code_Manager::action_load_providers
+ 	 * @uses Ad_Code_Manager::get_ad_codes
+	 * @uses Ad_Code_Manager::get_option
+	 * @uses Ad_Code_Manager::get_options
+	 * @uses Ad_Code_Manager::register_acm_post_type
+	 * @uses Ad_Code_Manager::register_ad_codes
+	 * @uses Doubleclick_For_Publishers_ACM_Provider::__construct
 	 * @group ui
 	 */
 	public function test_plugins_screen_has_filter_to_add_a_settings_action_link(): void {
@@ -36,6 +45,15 @@ final class PluginActionsTest extends TestCase {
 	 *
 	 * @covers Automattic\AdCodeManager\UI\Plugin_Actions::run
 	 * @covers Automattic\AdCodeManager\UI\Plugin_Actions::add_plugin_meta_links
+	 * @uses ACM_Provider::__construct
+	 * @uses Ad_Code_Manager::action_init
+	 * @uses Ad_Code_Manager::action_load_providers
+ 	 * @uses Ad_Code_Manager::get_ad_codes
+	 * @uses Ad_Code_Manager::get_option
+	 * @uses Ad_Code_Manager::get_options
+	 * @uses Ad_Code_Manager::register_acm_post_type
+	 * @uses Ad_Code_Manager::register_ad_codes
+	 * @uses Doubleclick_For_Publishers_ACM_Provider::__construct
 	 * @group ui
 	 */
 	public function test_plugins_screen_adds_a_settings_action_link(): void {


### PR DESCRIPTION
Also, update CI to streamline the jobs and include code coverage sent to [CodeCov](https://app.codecov.io/gh/Automattic/ad-code-manager).