### PR TITLE
Release 0.7.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,12 @@
 
 # Directories
 /.github                         export-ignore
+/.phpunit.cache                  export-ignore
 /.wordpress-org                  export-ignore
 /bin                             export-ignore
+/node_modules                    export-ignore
 /tests                           export-ignore
+/vendor                          export-ignore
 
 # Files
 /.editorconfig                   export-ignore
@@ -21,5 +24,9 @@
 /.gitignore                      export-ignore
 /.phpcs.xml.dist                 export-ignore
 /CHANGELOG.md                    export-ignore
+/clover.xml                      export-ignore
 /composer.json                   export-ignore
+/composer.lock                   export-ignore
+/package.json                    export-ignore
+/package-lock.json               export-ignore
 /phpunit.xml.dist                export-ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dependencies
-        run: npm install
-
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.phpunit.cache
+/node_modules
+/vendor
+
 /clover.xml
 /composer.lock
 /package-lock.json
-/vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2023-09-09
+
+### Changed
+- Cleanup package code
+
 ## [0.7.0] - 2023-09-09
 
 This version requires WordPress 5.7 and PHP 7.4 as a minimum. There are no new features.
@@ -161,6 +166,7 @@ Bug fix release.
 
 Initial release.
 
+[0.7.1]: https://github.com/Automattic/ad-code-manager/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/Automattic/ad-code-manager/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/Automattic/ad-code-manager/compare/0.5...0.6.0
 [0.5]: https://github.com/Automattic/ad-code-manager/compare/0.4.1...0.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ad Code Manager
 
-Stable tag: 0.7.0  
+Stable tag: 0.7.1  
 Requires at least: 5.7  
 Tested up to: 5.9  
 Requires PHP: 7.4  

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Ad Code Manager
  * Plugin URI:        https://wordpress.org/plugins/ad-code-manager/
  * Description:       Easy ad code management.
- * Version:           0.7.0
+ * Version:           0.7.1
  * Author:            Automattic and contributors
  * Author URI:        https://github.com/Automattic/ad-code-manager/graphs/contributors
  * Text Domain:       ad-code-manager
@@ -30,7 +30,7 @@ use Ad_Code_Manager;
 use Automattic\AdCodeManager\UI\Contextual_Help;
 use Automattic\AdCodeManager\UI\Plugin_Actions;
 
-const AD_CODE_MANAGER_VERSION = '0.7.0';
+const AD_CODE_MANAGER_VERSION = '0.7.1';
 const AD_CODE_MANAGER_FILE    = __FILE__;
 
 require_once __DIR__ . '/src/class-acm-provider.php';

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
 	"author": "Automattic",
 	"repository": "automattic/ad-code-manager",
 	"devDependencies": {
-		"@actions/github": "^2",
-		"replace-in-file": "^5",
-		"semver": "^7",
 		"version-bump-prompt": "^6.1.0"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ad-code-manager",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Easy ad code management.",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",


### PR DESCRIPTION
No need for redundant development packages and other files to be available in the distributed plugin.