### PR TITLE
Fix YAML syntax in GitHub Action for deploy to WordPress.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install SVN ( Subversion )
-          run: |
+      - name: Install SVN (Subversion)
+        run: |
           sudo apt-get update
           sudo apt-get install subversion
 


### PR DESCRIPTION
Fixes bad YAML syntax introduced in https://github.com/Automattic/ad-code-manager/pull/175.