### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '8.2' ]
-        wordpress: [ '5.7', '6.3' ]
+        wordpress: [ '6.4', 'latest' ]
         allowed_failure: [false]
         coverage: [false]
         include:
@@ -42,15 +42,6 @@ jobs:
             wordpress: 'latest'
             allowed_failure: true
             coverage: false
-          # Code coverage on latest PHP and WP.
-          - php: '8.2'
-            wordpress: 'latest'
-            allowed_failure: false
-            coverage: true
-        exclude:
-          # WordPress 5.7 doesn't support PHP 8.2.
-          - php: '8.2'
-            wordpress: '5.7'
       fail-fast: false
     continue-on-error: ${{ matrix.allowed_failure }}
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.7"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ad Code Manager
 
 Stable tag: 0.7.1  
-Requires at least: 5.7  
+Requires at least: 6.4  
 Tested up to: 5.9  
 Requires PHP: 7.4  
 License: GPLv2 or later  

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -19,7 +19,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/ad-code-manager/
  * Requires PHP:      7.4
- * Requires WP:       5.7
+ * Requires WP:       6.4
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.