### PR TITLE
Update minimum WordPress version to 6.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '8.2' ]
-        wordpress: [ '5.7', '6.3' ]
+        wordpress: [ '6.4', '6.8' ]
         allowed_failure: [false]
         coverage: [false]
         include:
@@ -47,10 +47,6 @@ jobs:
             wordpress: 'latest'
             allowed_failure: false
             coverage: true
-        exclude:
-          # WordPress 5.7 doesn't support PHP 8.2.
-          - php: '8.2'
-            wordpress: '5.7'
       fail-fast: false
     continue-on-error: ${{ matrix.allowed_failure }}
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.7"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ad Code Manager
 
 Stable tag: 0.7.1  
-Requires at least: 5.7  
-Tested up to: 5.9  
+Requires at least: 6.4  
+Tested up to: 6.8  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
@@ -25,7 +25,7 @@ Once this configuration is in place, the Ad Code Manager admin interface will al
 
 ## Installation
 
-The plugin requires PHP 7.4 or later. It is also tested WordPress 5.7 and later, though it may run on older versions.
+The plugin requires PHP 7.4 or later. It is also tested WordPress 6.4 and later, though it may run on older versions.
 
 Since the plugin is in its early stages, there are a couple additional configuration steps:
 

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -19,7 +19,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/ad-code-manager/
  * Requires PHP:      7.4
- * Requires WP:       5.7
+ * Requires WP:       6.4
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary
 - Updates the "Requires WP" header from 5.7 to 6.4
 - Updates test matrix to test against WP 6.4 and 6.8 (instead of 5.7 and 6.3)
 - Updates README minimum version to 6.4 and tested version to 6.8
 - Updates PHPCS minimum supported WP version to 6.4

## Context
This change aligns the plugin's minimum WordPress version requirement with current plugin standards and internal documentation.