### PR TITLE
Standardise CI configuration and add unit test infrastructure

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,22 @@
+# Directories
+/.git/
+/.github/
+/bin/
+/node_modules/
+/tests/
+/vendor/
+
+# Files
+.distignore
+.editorconfig
+.gitattributes
+.gitignore
+.phpcs.xml.dist
+.wp-env.json
+.wp-env.override.json
+CHANGELOG.md
+composer.json
+composer.lock
+package.json
+package-lock.json
+phpunit.xml.dist

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,46 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Configuration for Dependabot version updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Actions"
+      include: "scope"
+    open-pull-requests-limit: 5
 
-  # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "automattic/*"
+          - "dealerdirect/*"
+          - "php-parallel-lint/*"
+          - "phpcompatibility/*"
+          - "phpunit/*"
+          - "squizlabs/*"
+          - "yoast/*"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Composer"
+      include: "scope"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -11,6 +11,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Disable all permissions by default. Enable specific permissions per job.
+permissions: {}
+
 jobs:
   checkcs:
     name: Lint checks for PHP ${{ matrix.php }}
@@ -32,7 +35,7 @@ jobs:
 
     steps:
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: ${{ matrix.php }}
           coverage: none
@@ -41,20 +44,22 @@ jobs:
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register PHP lint violations to appear as file diff comments
-        uses: korelstar/phplint-problem-matcher@v1
+        uses: korelstar/phplint-problem-matcher@cb2b753750ec7bf13a7cde0a476df8c5605bdfb1 # v1.2.0
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register XML violations to appear as file diff comments
-        uses: korelstar/xmllint-problem-matcher@v1
+        uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -64,7 +69,7 @@ jobs:
       # @link https://github.com/marketplace/actions/xml-lint
       - name: Lint phpunit.xml.dist
         if: ${{ matrix.php >= 8.0 }}
-        uses: ChristophWurst/xmllint-action@v1
+        uses: ChristophWurst/xmllint-action@7c54ff113fc0f6d4588a15cb4dfe31b6ecca5212 # v1.2.1
         with:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,13 +6,18 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Disable all permissions by default. Enable specific permissions per job.
+permissions: {}
+
 jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Install SVN (Subversion)
         run: |
@@ -20,7 +25,7 @@ jobs:
           sudo apt-get install subversion
 
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,4 +80,4 @@ jobs:
           WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
       - name: Run integration tests
-        run: composer test-integration --no-interaction
+        run: composer test:integration --no-interaction

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Disable all permissions by default. Enable specific permissions per job.
+permissions: {}
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.
@@ -44,26 +47,32 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Install wordpress environment
         run: npm install -g @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: ${{ matrix.php }}
           coverage: none
           tools: composer
 
       - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        run: echo "::add-matcher::${TOOL_CACHE}/php.json"
+        env:
+          TOOL_CACHE: ${{ runner.tool_cache }}
 
       - name: Setup Problem Matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+        run: echo "::add-matcher::${TOOL_CACHE}/phpunit.json"
+        env:
+          TOOL_CACHE: ${{ runner.tool_cache }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       - name: Setup wp-env
         run: wp-env start

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,65 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/unit.yml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/unit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '7.4'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run unit tests
+        run: composer test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
-/.phpunit.cache
-/node_modules
-/vendor
+# Dependencies
+/node_modules/
+/vendor/
 
-/clover.xml
+# Composer
 /composer.lock
-/package-lock.json
+
+# Tests
+/.phpunit.cache/
+/clover.xml
+
+# Local config overrides
+/.phpcs.xml
+/phpcs.xml
+/phpunit.xml
+/.wp-env.override.json

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"automattic/vipwpcs": "^3",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"yoast/wp-test-utils": "^1"
+		"yoast/wp-test-utils": "^1.2"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"automattic/vipwpcs": "^3",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpunit/phpunit": "^9.6",
 		"yoast/wp-test-utils": "^1.2"
 	},
 	"config": {
@@ -49,8 +50,9 @@
 		"lint-ci": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
-		"test-integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/ad-code-manager ./vendor/bin/phpunit --no-coverage --order-by=random",
-		"test-integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/ad-code-manager /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --no-coverage --order-by=random'"
+		"test:unit": "@php ./vendor/bin/phpunit --testsuite Unit",
+		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/ad-code-manager ./vendor/bin/phpunit --testsuite integration --no-coverage --order-by=random",
+		"test:integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/ad-code-manager /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite integration --no-coverage --order-by=random'"
 	},
 	"scripts-descriptions": {
 		"coverage": "Run tests with code coverage reporting",
@@ -60,7 +62,8 @@
 		"i18n": "Generate a POT file for translation",
 		"lint": "Run PHP linting",
 		"lint-ci": "Run PHP linting and send results to stdout",
-		"test-integration": "Run integration tests in wp-env",
-		"test-integration-ms": "Run integration tests in multisite mode in wp-env"
+		"test:unit": "Run unit tests (no WordPress required)",
+		"test:integration": "Run integration tests in wp-env",
+		"test:integration-ms": "Run integration tests in multisite mode in wp-env"
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         bootstrap="./tests/Integration/bootstrap.php"
+         bootstrap="./tests/bootstrap.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
          forceCoversAnnotation="false"
@@ -15,6 +15,9 @@
 		 testdox="true"
          verbose="true">
     <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>

--- a/tests/Unit/AdCodeManagerTest.php
+++ b/tests/Unit/AdCodeManagerTest.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Unit tests for the Ad_Code_Manager class.
+ *
+ * @package Automattic\AdCodeManager\Tests\Unit
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\AdCodeManager\Tests\Unit;
+
+use Ad_Code_Manager;
+use Brain\Monkey\Functions;
+use stdClass;
+
+/**
+ * Test case for Ad_Code_Manager.
+ */
+class AdCodeManagerTest extends TestCase {
+
+	/**
+	 * The Ad_Code_Manager instance.
+	 *
+	 * @var Ad_Code_Manager
+	 */
+	private Ad_Code_Manager $ad_code_manager;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Stub WordPress functions.
+		Functions\stubs( [ '__' => null ] );
+
+		$this->ad_code_manager = new Ad_Code_Manager();
+
+		// Create a mock provider with whitelisted URLs.
+		$this->ad_code_manager->current_provider = new stdClass();
+		$this->ad_code_manager->current_provider->whitelisted_script_urls = [
+			'example.com',
+			'ads.google.com',
+			'secure.pagead2.googlesyndication.com',
+		];
+	}
+
+	/**
+	 * Test validate_script_url with empty URL returns true.
+	 */
+	public function testValidateScriptUrlEmptyReturnsTrue(): void {
+		$this->assertTrue( $this->ad_code_manager->validate_script_url( '' ) );
+	}
+
+	/**
+	 * Test validate_script_url with exact domain match.
+	 */
+	public function testValidateScriptUrlExactDomainMatch(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertTrue(
+			$this->ad_code_manager->validate_script_url( 'https://example.com/script.js' )
+		);
+	}
+
+	/**
+	 * Test validate_script_url with subdomain match.
+	 */
+	public function testValidateScriptUrlSubdomainMatch(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertTrue(
+			$this->ad_code_manager->validate_script_url( 'https://cdn.example.com/ads/script.js' )
+		);
+	}
+
+	/**
+	 * Test validate_script_url with non-whitelisted domain.
+	 */
+	public function testValidateScriptUrlNonWhitelistedDomain(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertFalse(
+			$this->ad_code_manager->validate_script_url( 'https://malicious-site.com/script.js' )
+		);
+	}
+
+	/**
+	 * Test validate_script_url prevents domain spoofing.
+	 *
+	 * Ensures that 'evilexample.com' doesn't match 'example.com'.
+	 */
+	public function testValidateScriptUrlPreventsDomainSpoofing(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertFalse(
+			$this->ad_code_manager->validate_script_url( 'https://evilexample.com/script.js' )
+		);
+	}
+
+	/**
+	 * Test validate_script_url with Google Ads URL.
+	 */
+	public function testValidateScriptUrlGoogleAds(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertTrue(
+			$this->ad_code_manager->validate_script_url( 'https://ads.google.com/ad-manager/tag.js' )
+		);
+	}
+
+	/**
+	 * Test validate_script_url with deep subdomain.
+	 */
+	public function testValidateScriptUrlDeepSubdomain(): void {
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		$this->assertTrue(
+			$this->ad_code_manager->validate_script_url( 'https://a.b.c.example.com/script.js' )
+		);
+	}
+
+	/**
+	 * Test filter_output_tokens adds URL vars as tokens.
+	 */
+	public function testFilterOutputTokensAddsUrlVars(): void {
+		$code_to_display = [
+			'url_vars' => [
+				'site_id'  => '12345',
+				'zone'     => 'header',
+				'width'    => '728',
+				'height'   => '90',
+			],
+		];
+
+		$output_tokens = $this->ad_code_manager->filter_output_tokens( [], 'test_tag', $code_to_display );
+
+		$this->assertArrayHasKey( '%site_id%', $output_tokens );
+		$this->assertArrayHasKey( '%zone%', $output_tokens );
+		$this->assertArrayHasKey( '%width%', $output_tokens );
+		$this->assertArrayHasKey( '%height%', $output_tokens );
+		$this->assertSame( '12345', $output_tokens['%site_id%'] );
+		$this->assertSame( 'header', $output_tokens['%zone%'] );
+	}
+
+	/**
+	 * Test filter_output_tokens returns original tokens when no URL vars.
+	 */
+	public function testFilterOutputTokensReturnsOriginalWhenNoUrlVars(): void {
+		$code_to_display = [];
+		$original_tokens = [ '%existing%' => 'value' ];
+
+		$output_tokens = $this->ad_code_manager->filter_output_tokens(
+			$original_tokens,
+			'test_tag',
+			$code_to_display
+		);
+
+		$this->assertSame( $original_tokens, $output_tokens );
+	}
+
+	/**
+	 * Test filter_output_tokens preserves existing tokens.
+	 */
+	public function testFilterOutputTokensPreservesExistingTokens(): void {
+		$code_to_display = [
+			'url_vars' => [
+				'new_var' => 'new_value',
+			],
+		];
+		$original_tokens = [ '%existing%' => 'value' ];
+
+		$output_tokens = $this->ad_code_manager->filter_output_tokens(
+			$original_tokens,
+			'test_tag',
+			$code_to_display
+		);
+
+		$this->assertArrayHasKey( '%existing%', $output_tokens );
+		$this->assertArrayHasKey( '%new_var%', $output_tokens );
+	}
+}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Base test case for unit tests.
+ *
+ * @package Automattic\AdCodeManager\Tests\Unit
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\AdCodeManager\Tests\Unit;
+
+use Yoast\WPTestUtils\BrainMonkey\TestCase as BrainMonkeyTestCase;
+
+/**
+ * Base test case for unit tests.
+ */
+abstract class TestCase extends BrainMonkeyTestCase {
+	// Extend as needed.
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPUnit bootstrap file for Ad Code Manager plugin tests.
+ *
+ * @package Automattic\AdCodeManager
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\AdCodeManager\Tests;
+
+// Composer autoloader.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+// Check for a `--testsuite Unit` arg when calling phpunit.
+$argv_local = $GLOBALS['argv'] ?? [];
+$key        = (int) array_search( '--testsuite', $argv_local, true );
+$is_unit    = false;
+
+// Check for --testsuite Unit (two separate args).
+if ( $key && isset( $argv_local[ $key + 1 ] ) && 'Unit' === $argv_local[ $key + 1 ] ) {
+	$is_unit = true;
+}
+
+// Check for --testsuite=Unit (single arg with equals).
+foreach ( $argv_local as $arg ) {
+	if ( '--testsuite=Unit' === $arg ) {
+		$is_unit = true;
+		break;
+	}
+}
+
+if ( $is_unit ) {
+	// Unit tests use Brain Monkey - no WordPress loaded.
+	// Load plugin classes that can be tested without WordPress.
+	require_once dirname( __DIR__ ) . '/src/class-acm-provider.php';
+	require_once dirname( __DIR__ ) . '/src/class-ad-code-manager.php';
+	require_once __DIR__ . '/Unit/TestCase.php';
+	return;
+}
+
+// For integration tests, delegate to the Integration bootstrap.
+require_once __DIR__ . '/Integration/bootstrap.php';


### PR DESCRIPTION
This pull request modernises the plugin's development infrastructure by standardising CI workflows and introducing proper unit testing capabilities.

## Summary

- Standardise GitHub Actions with pinned SHA versions and security hardening
- Reconfigure Dependabot for weekly updates with dependency grouping
- Add Brain Monkey-based unit tests for isolated testing without WordPress
- Add .distignore for cleaner release packages
- Reorganise .gitignore with clear sections

## Test plan

- [x] Verify unit tests pass via `composer test:unit`
- [x] Verify integration tests still work via `composer test:integration`
- [ ] Check GitHub Actions workflows run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)