### PR TITLE
ci: standardise test matrix and update readme

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,20 +30,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.4', '8.3' ]
-        wordpress: [ '6.4', '6.8' ]
-        allowed_failure: [false]
         include:
-          # Check upcoming WP.
-          - php: '8.3'
-            wordpress: 'master'
-            allowed_failure: true
-          # Check upcoming PHP.
-          - php: '8.5'
-            wordpress: '6.8'
-            allowed_failure: true
+          # Check lowest supported WP version, with the lowest supported PHP.
+          - wordpress: '6.4'
+            php: '7.4'
+          # Check latest WP with the latest PHP.
+          - wordpress: 'master'
+            php: 'latest'
       fail-fast: false
-    continue-on-error: ${{ matrix.allowed_failure }}
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 0.7.1  
 Requires at least: 6.4  
-Tested up to: 6.8  
+Tested up to: 6.9  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Summary

- Updates CI workflow to test against WP 6.4 and master with PHP 7.4 and latest
- Removes allowed_failure flag so CI fails if tests fail on any supported configuration
- Updates README to reflect tested versions (WP 6.9)

## Test plan

- [ ] CI passes on WP 6.4 with PHP 7.4
- [ ] CI passes on WP master with PHP latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)