### PR TITLE
Ensure row actions display in first data column

### DIFF
--- a/src/class-acm-wp-list-table.php
+++ b/src/class-acm-wp-list-table.php
@@ -169,13 +169,48 @@ class ACM_WP_List_Table extends WP_List_Table {
 			case 'operator':
 				return ( ! empty( $item['operator'] ) ) ? $item['operator'] : $ad_code_manager->logical_operator;
 			default:
-				// @todo need to make the first column (whatever it is filtered) to show row actions
-				// Handle custom columns, if any
+				// Handle custom columns, if any.
 				if ( isset( $item['url_vars'][ $column_name ] ) ) {
-					return esc_html( $item['url_vars'][ $column_name ] );
+					$output = esc_html( $item['url_vars'][ $column_name ] );
+
+					// Add row actions to the first data column (after cb and id).
+					if ( $this->is_first_data_column( $column_name ) ) {
+						$output .= $this->row_actions_output( $item );
+					}
+
+					return $output;
 				}
 				break;
 		}
+	}
+
+	/**
+	 * Check if the given column is the first data column.
+	 *
+	 * The first data column is the first column after 'cb' (checkbox) and 'id' (hidden).
+	 * This column should display the row actions (edit/delete links).
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param string $column_name The column name to check.
+	 * @return bool True if this is the first data column, false otherwise.
+	 */
+	protected function is_first_data_column( $column_name ) {
+		$columns = $this->get_columns();
+
+		// Skip 'cb' and 'id' columns to find the first data column.
+		$skip_columns = array( 'cb', 'id' );
+
+		foreach ( $columns as $key => $label ) {
+			if ( in_array( $key, $skip_columns, true ) ) {
+				continue;
+			}
+
+			// The first column we encounter after skipping is the first data column.
+			return $key === $column_name;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Fixes missing row actions (edit/delete) when providers don't define custom column methods
- Adds `is_first_data_column()` helper to detect the first data column (after checkbox and ID)
- Automatically appends row actions to the first data column in `column_default()`

Previously, if a provider didn't define a specific `column_{name}` method for the first column, users couldn't edit or delete ad codes from that row.

## Test plan

- [ ] Switch to a provider that uses default column rendering
- [ ] Verify Edit/Delete links appear on hover over the first data column
- [ ] Existing providers with custom column methods still work correctly
- [ ] Run integration tests: `composer test:integration`

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)