### PR TITLE
feat: add autocomplete for conditional arguments

### DIFF
--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -67,17 +67,30 @@
 		handleConditionalChange: function( $select ) {
 			var conditional = $select.val();
 			var $argumentsContainer = $select.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
-			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
 
-			// Destroy existing Select2 if present.
-			if ( $input.hasClass( 'select2-hidden-accessible' ) ) {
-				$input.select2( 'destroy' );
-				// Remove the Select2 container that gets left behind.
-				$argumentsContainer.find( '.select2-container' ).remove();
+			// Check if we have a Select2 select element or the original input.
+			var $existingSelect = $argumentsContainer.find( 'select.acm-autocomplete-select' );
+			var $hiddenInput = $argumentsContainer.find( 'input[data-original-name="acm-arguments[]"]' );
+
+			// If there's a Select2 select, destroy it and restore the input.
+			if ( $existingSelect.length ) {
+				var currentVal = $existingSelect.val();
+				$existingSelect.select2( 'destroy' );
+				$existingSelect.remove();
+
+				// Restore the original input's name and visibility.
+				$hiddenInput
+					.attr( 'name', 'acm-arguments[]' )
+					.removeAttr( 'data-original-name' )
+					.val( currentVal || '' )
+					.show();
 			}
 
-			// Reset the input to a visible text input.
-			$input.val( '' ).attr( 'type', 'text' ).show();
+			// Get the input (either restored or original).
+			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
+
+			// Reset the input value.
+			$input.val( '' );
 
 			// If this conditional supports autocomplete, initialize it.
 			if ( conditional && this.hasAutocomplete( conditional ) ) {
@@ -123,12 +136,27 @@
 			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
 			var currentValue = $input.val();
 
-			// Select2 with AJAX requires a hidden input, not text input.
-			// Convert the text input to hidden type for Select2.
-			$input.attr( 'type', 'hidden' );
+			// Hide the original input.
+			$input.hide();
+
+			// Create a select element for Select2 (it requires a <select> for AJAX).
+			var $select = $( '<select></select>' )
+				.attr( 'name', 'acm-arguments[]' )
+				.addClass( 'acm-autocomplete-select' );
+
+			// If there's an existing value, add it as an option.
+			if ( currentValue ) {
+				$select.append( new Option( currentValue, currentValue, true, true ) );
+			}
+
+			// Insert the select after the hidden input.
+			$input.after( $select );
+
+			// Remove the name from the original input to avoid duplicate submission.
+			$input.removeAttr( 'name' ).attr( 'data-original-name', 'acm-arguments[]' );
 
 			// Initialize Select2 with AJAX.
-			$input.select2({
+			$select.select2({
 				ajax: {
 					url: acmAutocomplete.ajaxUrl,
 					dataType: 'json',
@@ -185,12 +213,6 @@
 				},
 				width: '100%'
 			});
-
-			// If there's an existing value, set it.
-			if ( currentValue ) {
-				var option = new Option( currentValue, currentValue, true, true );
-				$input.append( option ).trigger( 'change' );
-			}
 		},
 
 		/**

--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -16,6 +16,15 @@
 	var ConditionalAutocomplete = {
 
 		/**
+		 * Check if Select2 is available.
+		 *
+		 * @return {boolean} True if Select2 is loaded.
+		 */
+		isSelect2Available: function() {
+			return typeof $.fn.select2 === 'function';
+		},
+
+		/**
 		 * Initialize the autocomplete functionality.
 		 */
 		init: function() {
@@ -30,8 +39,8 @@
 		bindEvents: function() {
 			var self = this;
 
-			// Use event delegation for dynamically added conditional selects.
-			$( document ).on( 'change', 'select[name="acm-conditionals[]"]', function() {
+			// Use event delegation for dynamically added conditional selects (Add form only).
+			$( document ).on( 'change', '#add-adcode select[name="acm-conditionals[]"]', function() {
 				self.handleConditionalChange( $( this ) );
 				self.updateAddButtonVisibility();
 			});
@@ -40,7 +49,7 @@
 			$( document ).on( 'click', '.add-more-conditionals', function() {
 				// Small delay to allow DOM to update.
 				setTimeout( function() {
-					self.initExistingFields();
+					self.cleanupNewRows();
 					self.updateAddButtonVisibility();
 				}, 100 );
 			});
@@ -55,11 +64,13 @@
 
 		/**
 		 * Initialize any existing conditional fields on page load.
+		 * Only targets the Add form, not inline edit.
 		 */
 		initExistingFields: function() {
 			var self = this;
 
-			$( 'select[name="acm-conditionals[]"]' ).each( function() {
+			// Only target the Add form to avoid conflicts with inline edit.
+			$( '#add-adcode select[name="acm-conditionals[]"]' ).each( function() {
 				var $select = $( this );
 				var conditional = $select.val();
 				var $argumentsContainer = $select.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
@@ -72,8 +83,55 @@
 
 				// Show arguments and init autocomplete if applicable.
 				$argumentsContainer.show();
-				if ( self.hasAutocomplete( conditional ) ) {
+
+				// Only init autocomplete if not already initialized.
+				var $existingSelect2 = $argumentsContainer.find( 'select.acm-autocomplete-select' );
+				if ( self.hasAutocomplete( conditional ) && ! $existingSelect2.length ) {
 					self.initAutocomplete( $select );
+				}
+			});
+		},
+
+		/**
+		 * Clean up newly added conditional rows.
+		 *
+		 * When rows are cloned from the master template, they may contain
+		 * leftover Select2 markup that needs to be cleaned up.
+		 */
+		cleanupNewRows: function() {
+			var self = this;
+
+			$( 'select[name="acm-conditionals[]"]' ).each( function() {
+				var $conditionalSelect = $( this );
+				var conditional = $conditionalSelect.val();
+				var $argumentsContainer = $conditionalSelect.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
+
+				// If no conditional is selected, clean up any Select2 remnants.
+				if ( ! conditional ) {
+					// Remove any cloned Select2 elements.
+					$argumentsContainer.find( 'select.acm-autocomplete-select' ).remove();
+					$argumentsContainer.find( '.select2-container' ).remove();
+
+					// Restore the original input if it was hidden.
+					var $hiddenInput = $argumentsContainer.find( 'input[data-original-name="acm-arguments[]"]' );
+					if ( $hiddenInput.length ) {
+						$hiddenInput
+							.attr( 'name', 'acm-arguments[]' )
+							.removeAttr( 'data-original-name' )
+							.val( '' )
+							.show();
+					}
+
+					// Ensure input exists and is visible with correct attributes.
+					var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
+					if ( ! $input.length ) {
+						$argumentsContainer.prepend( '<input name="acm-arguments[]" type="text" value="" size="20" />' );
+					} else {
+						$input.val( '' ).attr( 'type', 'text' ).show();
+					}
+
+					// Hide the arguments container since no conditional is selected.
+					$argumentsContainer.hide();
 				}
 			});
 		},
@@ -160,6 +218,11 @@
 				return;
 			}
 
+			// Skip if Select2 is not available (CDN failed to load).
+			if ( ! this.isSelect2Available() ) {
+				return;
+			}
+
 			var $argumentsContainer = $conditionalSelect.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
 			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
 			var currentValue = $input.val();
@@ -183,8 +246,14 @@
 			// Remove the name from the original input to avoid duplicate submission.
 			$input.removeAttr( 'name' ).attr( 'data-original-name', 'acm-arguments[]' );
 
+			// Determine the dropdown parent - use body for inline edit to avoid z-index issues.
+			var $dropdownParent = $argumentsContainer.closest( '.acm-editor-row' ).length
+				? $( 'body' )
+				: $argumentsContainer;
+
 			// Initialize Select2 with AJAX.
 			$select.select2({
+				dropdownParent: $dropdownParent,
 				ajax: {
 					url: acmAutocomplete.ajaxUrl,
 					dataType: 'json',

--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -21,6 +21,7 @@
 		init: function() {
 			this.bindEvents();
 			this.initExistingFields();
+			this.updateAddButtonVisibility();
 		},
 
 		/**
@@ -32,6 +33,7 @@
 			// Use event delegation for dynamically added conditional selects.
 			$( document ).on( 'change', 'select[name="acm-conditionals[]"]', function() {
 				self.handleConditionalChange( $( this ) );
+				self.updateAddButtonVisibility();
 			});
 
 			// Re-initialize when new conditional rows are added.
@@ -39,6 +41,14 @@
 				// Small delay to allow DOM to update.
 				setTimeout( function() {
 					self.initExistingFields();
+					self.updateAddButtonVisibility();
+				}, 100 );
+			});
+
+			// Handle remove conditional click.
+			$( document ).on( 'click', '.acm-remove-conditional', function() {
+				setTimeout( function() {
+					self.updateAddButtonVisibility();
 				}, 100 );
 			});
 		},
@@ -52,8 +62,17 @@
 			$( 'select[name="acm-conditionals[]"]' ).each( function() {
 				var $select = $( this );
 				var conditional = $select.val();
+				var $argumentsContainer = $select.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
 
-				if ( conditional && self.hasAutocomplete( conditional ) ) {
+				// Hide arguments for empty selection or no-parameter conditionals.
+				if ( ! conditional || self.hasNoParameters( conditional ) ) {
+					$argumentsContainer.hide();
+					return;
+				}
+
+				// Show arguments and init autocomplete if applicable.
+				$argumentsContainer.show();
+				if ( self.hasAutocomplete( conditional ) ) {
 					self.initAutocomplete( $select );
 				}
 			});
@@ -92,8 +111,8 @@
 			// Reset the input value.
 			$input.val( '' );
 
-			// Hide arguments container for conditionals that take no parameters.
-			if ( conditional && this.hasNoParameters( conditional ) ) {
+			// Hide arguments container when no conditional selected or for conditionals that take no parameters.
+			if ( ! conditional || this.hasNoParameters( conditional ) ) {
 				$argumentsContainer.hide();
 				return;
 			}
@@ -270,6 +289,31 @@
 			];
 
 			return noParamConditionals.indexOf( conditional ) !== -1;
+		},
+
+		/**
+		 * Update visibility of the "Add another condition" button.
+		 *
+		 * Shows the button only when at least one condition is selected.
+		 */
+		updateAddButtonVisibility: function() {
+			var $form = $( '#add-adcode' );
+			var $addButton = $form.find( '.form-add-more' );
+			var hasSelectedCondition = false;
+
+			// Check if any conditional select has a value.
+			$form.find( 'select[name="acm-conditionals[]"]' ).each( function() {
+				if ( $( this ).val() ) {
+					hasSelectedCondition = true;
+					return false; // Break the loop.
+				}
+			});
+
+			if ( hasSelectedCondition ) {
+				$addButton.addClass( 'visible' );
+			} else {
+				$addButton.removeClass( 'visible' );
+			}
 		}
 	};
 

--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -72,9 +72,11 @@
 			// Destroy existing Select2 if present.
 			if ( $input.hasClass( 'select2-hidden-accessible' ) ) {
 				$input.select2( 'destroy' );
+				// Remove the Select2 container that gets left behind.
+				$argumentsContainer.find( '.select2-container' ).remove();
 			}
 
-			// Reset the input.
+			// Reset the input to a visible text input.
 			$input.val( '' ).attr( 'type', 'text' ).show();
 
 			// If this conditional supports autocomplete, initialize it.
@@ -120,6 +122,10 @@
 			var $argumentsContainer = $conditionalSelect.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
 			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
 			var currentValue = $input.val();
+
+			// Select2 with AJAX requires a hidden input, not text input.
+			// Convert the text input to hidden type for Select2.
+			$input.attr( 'type', 'hidden' );
 
 			// Initialize Select2 with AJAX.
 			$input.select2({

--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -92,6 +92,15 @@
 			// Reset the input value.
 			$input.val( '' );
 
+			// Hide arguments container for conditionals that take no parameters.
+			if ( conditional && this.hasNoParameters( conditional ) ) {
+				$argumentsContainer.hide();
+				return;
+			}
+
+			// Show arguments container for conditionals that take parameters.
+			$argumentsContainer.show();
+
 			// If this conditional supports autocomplete, initialize it.
 			if ( conditional && this.hasAutocomplete( conditional ) ) {
 				this.initAutocomplete( $select );
@@ -232,6 +241,35 @@
 			};
 
 			return placeholders[ conditional ] || 'Search...';
+		},
+
+		/**
+		 * Check if a conditional takes no parameters.
+		 *
+		 * @param {string} conditional The conditional function name.
+		 * @return {boolean} True if the conditional takes no parameters.
+		 */
+		hasNoParameters: function( conditional ) {
+			var noParamConditionals = [
+				'is_home',
+				'is_front_page',
+				'is_archive',
+				'is_search',
+				'is_404',
+				'is_date',
+				'is_year',
+				'is_month',
+				'is_day',
+				'is_time',
+				'is_feed',
+				'is_comment_feed',
+				'is_trackback',
+				'is_preview',
+				'is_paged',
+				'is_admin'
+			];
+
+			return noParamConditionals.indexOf( conditional ) !== -1;
 		}
 	};
 

--- a/acm-autocomplete.js
+++ b/acm-autocomplete.js
@@ -1,0 +1,215 @@
+/**
+ * Conditional Autocomplete for Ad Code Manager
+ *
+ * Provides Select2-powered autocomplete for conditional arguments
+ * like categories, tags, pages, etc.
+ *
+ * @since 0.9.0
+ */
+( function( $, acmAutocomplete ) {
+	'use strict';
+
+	if ( typeof acmAutocomplete === 'undefined' ) {
+		return;
+	}
+
+	var ConditionalAutocomplete = {
+
+		/**
+		 * Initialize the autocomplete functionality.
+		 */
+		init: function() {
+			this.bindEvents();
+			this.initExistingFields();
+		},
+
+		/**
+		 * Bind event handlers.
+		 */
+		bindEvents: function() {
+			var self = this;
+
+			// Use event delegation for dynamically added conditional selects.
+			$( document ).on( 'change', 'select[name="acm-conditionals[]"]', function() {
+				self.handleConditionalChange( $( this ) );
+			});
+
+			// Re-initialize when new conditional rows are added.
+			$( document ).on( 'click', '.add-more-conditionals', function() {
+				// Small delay to allow DOM to update.
+				setTimeout( function() {
+					self.initExistingFields();
+				}, 100 );
+			});
+		},
+
+		/**
+		 * Initialize any existing conditional fields on page load.
+		 */
+		initExistingFields: function() {
+			var self = this;
+
+			$( 'select[name="acm-conditionals[]"]' ).each( function() {
+				var $select = $( this );
+				var conditional = $select.val();
+
+				if ( conditional && self.hasAutocomplete( conditional ) ) {
+					self.initAutocomplete( $select );
+				}
+			});
+		},
+
+		/**
+		 * Handle when a conditional select changes.
+		 *
+		 * @param {jQuery} $select The conditional select element.
+		 */
+		handleConditionalChange: function( $select ) {
+			var conditional = $select.val();
+			var $argumentsContainer = $select.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
+			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
+
+			// Destroy existing Select2 if present.
+			if ( $input.hasClass( 'select2-hidden-accessible' ) ) {
+				$input.select2( 'destroy' );
+			}
+
+			// Reset the input.
+			$input.val( '' ).attr( 'type', 'text' ).show();
+
+			// If this conditional supports autocomplete, initialize it.
+			if ( conditional && this.hasAutocomplete( conditional ) ) {
+				this.initAutocomplete( $select );
+			}
+		},
+
+		/**
+		 * Check if a conditional has autocomplete configuration.
+		 *
+		 * @param {string} conditional The conditional function name.
+		 * @return {boolean} True if autocomplete is available.
+		 */
+		hasAutocomplete: function( conditional ) {
+			return acmAutocomplete.conditionals.hasOwnProperty( conditional );
+		},
+
+		/**
+		 * Get the autocomplete configuration for a conditional.
+		 *
+		 * @param {string} conditional The conditional function name.
+		 * @return {Object|null} The configuration or null.
+		 */
+		getConfig: function( conditional ) {
+			return acmAutocomplete.conditionals[ conditional ] || null;
+		},
+
+		/**
+		 * Initialize Select2 autocomplete on an arguments input.
+		 *
+		 * @param {jQuery} $conditionalSelect The conditional select element.
+		 */
+		initAutocomplete: function( $conditionalSelect ) {
+			var self = this;
+			var conditional = $conditionalSelect.val();
+			var config = this.getConfig( conditional );
+
+			if ( ! config ) {
+				return;
+			}
+
+			var $argumentsContainer = $conditionalSelect.closest( '.conditional-single-field' ).find( '.conditional-arguments' );
+			var $input = $argumentsContainer.find( 'input[name="acm-arguments[]"]' );
+			var currentValue = $input.val();
+
+			// Initialize Select2 with AJAX.
+			$input.select2({
+				ajax: {
+					url: acmAutocomplete.ajaxUrl,
+					dataType: 'json',
+					delay: 250,
+					data: function( params ) {
+						return {
+							action: 'acm_search_terms',
+							nonce: acmAutocomplete.nonce,
+							search: params.term,
+							conditional: conditional,
+							type: config.type,
+							taxonomy: config.taxonomy || '',
+							post_type: config.post_type || ''
+						};
+					},
+					processResults: function( response ) {
+						if ( response.success && response.data.results ) {
+							return {
+								results: response.data.results
+							};
+						}
+						return { results: [] };
+					},
+					cache: true
+				},
+				minimumInputLength: acmAutocomplete.minChars,
+				placeholder: self.getPlaceholder( conditional ),
+				allowClear: true,
+				tags: true, // Allow custom values (user can type their own).
+				createTag: function( params ) {
+					var term = $.trim( params.term );
+					if ( term === '' ) {
+						return null;
+					}
+					return {
+						id: term,
+						text: term,
+						newTag: true
+					};
+				},
+				language: {
+					inputTooShort: function() {
+						return acmAutocomplete.i18n.inputTooShort;
+					},
+					searching: function() {
+						return acmAutocomplete.i18n.searching;
+					},
+					noResults: function() {
+						return acmAutocomplete.i18n.noResults;
+					},
+					errorLoading: function() {
+						return acmAutocomplete.i18n.errorLoading;
+					}
+				},
+				width: '100%'
+			});
+
+			// If there's an existing value, set it.
+			if ( currentValue ) {
+				var option = new Option( currentValue, currentValue, true, true );
+				$input.append( option ).trigger( 'change' );
+			}
+		},
+
+		/**
+		 * Get placeholder text for a conditional.
+		 *
+		 * @param {string} conditional The conditional function name.
+		 * @return {string} The placeholder text.
+		 */
+		getPlaceholder: function( conditional ) {
+			var placeholders = {
+				'is_category': acmAutocomplete.i18n.searchCategories || 'Search categories...',
+				'has_category': acmAutocomplete.i18n.searchCategories || 'Search categories...',
+				'is_tag': acmAutocomplete.i18n.searchTags || 'Search tags...',
+				'has_tag': acmAutocomplete.i18n.searchTags || 'Search tags...',
+				'is_page': acmAutocomplete.i18n.searchPages || 'Search pages...',
+				'is_single': acmAutocomplete.i18n.searchPosts || 'Search posts...'
+			};
+
+			return placeholders[ conditional ] || 'Search...';
+		}
+	};
+
+	// Initialize when document is ready.
+	$( document ).ready( function() {
+		ConditionalAutocomplete.init();
+	});
+
+} )( jQuery, window.acmAutocomplete );

--- a/acm.css
+++ b/acm.css
@@ -160,6 +160,22 @@ tr:hover .row-actions {
 
 .acm-global-options {
 	clear: both;
+	margin-bottom: 20px;
+}
+
+.acm-global-options .acm-config-form p {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin: 0;
+}
+
+.acm-global-options .acm-config-form label {
+	font-weight: 600;
+}
+
+.acm-global-options .acm-config-form .button {
+	margin-left: 10px;
 }
 
 .acm-global-options input[type="text"] {
@@ -170,4 +186,56 @@ tr:hover .row-actions {
 .acm-global-options #provider-field label {
 	float: left;
 	width: 125px;
+}
+
+/* Ensure conditional row has consistent height even when arguments hidden */
+#add-adcode .conditional-single-field {
+	min-height: 36px;
+	margin-bottom: 8px;
+}
+
+/* Select2 styling for conditional autocomplete */
+#add-adcode .conditional-arguments .select2-container {
+	width: 100% !important;
+}
+
+#add-adcode .conditional-arguments .select2-container--default .select2-selection--single {
+	height: 30px;
+	border-color: #8c8f94;
+	border-radius: 4px;
+}
+
+#add-adcode .conditional-arguments .select2-container--default .select2-selection--single .select2-selection__rendered {
+	line-height: 28px;
+	padding-left: 8px;
+}
+
+#add-adcode .conditional-arguments .select2-container--default .select2-selection--single .select2-selection__arrow {
+	height: 28px;
+}
+
+/* Inline edit Select2 styling */
+.inline-edit-col .conditional-arguments .select2-container {
+	width: 70% !important;
+	margin-bottom: 5px;
+}
+
+/* Hide Add button initially until first condition is selected */
+#add-adcode .form-add-more {
+	display: none;
+}
+
+#add-adcode .form-add-more.visible {
+	display: block;
+}
+
+/* Operator field styling in inline edit */
+.inline-edit-col .acm-operator-field {
+	clear: both;
+	margin-top: 10px;
+	padding-top: 10px;
+}
+
+.inline-edit-col .acm-operator-field .acm-section-label {
+	margin-bottom: 5px;
 }

--- a/ad-code-manager.php
+++ b/ad-code-manager.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Automattic\AdCodeManager;
 
 use Ad_Code_Manager;
+use Automattic\AdCodeManager\UI\Conditional_Autocomplete;
 use Automattic\AdCodeManager\UI\Contextual_Help;
 use Automattic\AdCodeManager\UI\Plugin_Actions;
 
@@ -37,6 +38,7 @@ require_once __DIR__ . '/src/class-acm-provider.php';
 require_once __DIR__ . '/src/class-acm-wp-list-table.php';
 require_once __DIR__ . '/src/class-acm-widget.php';
 require_once __DIR__ . '/src/class-ad-code-manager.php';
+require_once __DIR__ . '/src/UI/class-conditional-autocomplete.php';
 require_once __DIR__ . '/src/UI/class-contextual-help.php';
 require_once __DIR__ . '/src/UI/class-plugin-actions.php';
 
@@ -51,6 +53,9 @@ add_action(
 add_action(
 	'admin_init',
 	function () {
+		$conditional_autocomplete = new Conditional_Autocomplete();
+		$conditional_autocomplete->run();
+
 		$contextual_help = new Contextual_Help();
 		$contextual_help->run();
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
             <directory suffix="Test.php">tests/Unit</directory>
         </testsuite>
         <testsuite name="integration">
-            <directory>tests/Integration</directory>
+            <directory suffix="Test.php">tests/Integration</directory>
         </testsuite>
     </testsuites>
 

--- a/src/UI/class-conditional-autocomplete.php
+++ b/src/UI/class-conditional-autocomplete.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Conditional Autocomplete functionality for Ad Code Manager.
+ *
+ * Provides autocomplete/dropdown for conditional arguments like categories, tags, etc.
+ *
+ * @package Automattic\AdCodeManager\UI
+ * @since 0.9.0
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\AdCodeManager\UI;
+
+/**
+ * Handles autocomplete functionality for conditional arguments.
+ *
+ * @since 0.9.0
+ */
+final class Conditional_Autocomplete {
+
+	/**
+	 * Minimum characters before autocomplete starts searching.
+	 *
+	 * @var int
+	 */
+	private const MIN_CHARS = 3;
+
+	/**
+	 * Maximum number of results to return.
+	 *
+	 * @var int
+	 */
+	private const MAX_RESULTS = 100;
+
+	/**
+	 * Register action and filter hook callbacks.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_ajax_acm_search_terms', array( $this, 'ajax_search_terms' ) );
+	}
+
+	/**
+	 * Enqueue scripts and styles for the autocomplete functionality.
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
+	 * @return void
+	 */
+	public function enqueue_scripts( string $hook_suffix ): void {
+		if ( 'settings_page_ad-code-manager' !== $hook_suffix ) {
+			return;
+		}
+
+		// Enqueue Select2 from WordPress (available since WP 4.0).
+		wp_enqueue_script( 'selectWoo' );
+		wp_enqueue_style( 'select2' );
+
+		// Enqueue our autocomplete handler.
+		wp_enqueue_script(
+			'acm-conditional-autocomplete',
+			plugins_url( 'acm-autocomplete.js', dirname( __DIR__, 2 ) . '/ad-code-manager.php' ),
+			array( 'jquery', 'selectWoo' ),
+			filemtime( dirname( __DIR__, 2 ) . '/acm-autocomplete.js' ),
+			true
+		);
+
+		// Pass configuration to JavaScript.
+		wp_localize_script(
+			'acm-conditional-autocomplete',
+			'acmAutocomplete',
+			array(
+				'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+				'nonce'        => wp_create_nonce( 'acm-search-terms' ),
+				'minChars'     => self::MIN_CHARS,
+				'conditionals' => $this->get_autocomplete_conditionals(),
+				'i18n'         => array(
+					'searching'     => __( 'Searching...', 'ad-code-manager' ),
+					'noResults'     => __( 'No results found', 'ad-code-manager' ),
+					'inputTooShort' => sprintf(
+						/* translators: %d: minimum number of characters */
+						__( 'Please enter %d or more characters', 'ad-code-manager' ),
+						self::MIN_CHARS
+					),
+					'errorLoading'  => __( 'Error loading results', 'ad-code-manager' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get the conditionals that support autocomplete.
+	 *
+	 * Returns a mapping of conditional function names to their search configuration.
+	 *
+	 * @return array<string, array{type: string, taxonomy?: string, post_type?: string}>
+	 */
+	private function get_autocomplete_conditionals(): array {
+		$conditionals = array(
+			'is_category'  => array(
+				'type'     => 'taxonomy',
+				'taxonomy' => 'category',
+			),
+			'has_category' => array(
+				'type'     => 'taxonomy',
+				'taxonomy' => 'category',
+			),
+			'is_tag'       => array(
+				'type'     => 'taxonomy',
+				'taxonomy' => 'post_tag',
+			),
+			'has_tag'      => array(
+				'type'     => 'taxonomy',
+				'taxonomy' => 'post_tag',
+			),
+			'is_page'      => array(
+				'type'      => 'post_type',
+				'post_type' => 'page',
+			),
+			'is_single'    => array(
+				'type'      => 'post_type',
+				'post_type' => 'post',
+			),
+		);
+
+		/**
+		 * Filters the conditionals that support autocomplete.
+		 *
+		 * Allows themes and plugins to add or modify which conditionals
+		 * get autocomplete functionality and how they search.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param array $conditionals Associative array of conditional configurations.
+		 *                            Each key is a conditional function name.
+		 *                            Each value is an array with:
+		 *                            - 'type': 'taxonomy' or 'post_type'
+		 *                            - 'taxonomy': (for taxonomy type) The taxonomy to search
+		 *                            - 'post_type': (for post_type type) The post type to search
+		 */
+		return apply_filters( 'acm_autocomplete_conditionals', $conditionals );
+	}
+
+	/**
+	 * AJAX handler for searching terms.
+	 *
+	 * @return void
+	 */
+	public function ajax_search_terms(): void {
+		check_ajax_referer( 'acm-search-terms', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Permission denied.', 'ad-code-manager' ) ) );
+		}
+
+		$search      = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+		$conditional = isset( $_GET['conditional'] ) ? sanitize_key( $_GET['conditional'] ) : '';
+		$type        = isset( $_GET['type'] ) ? sanitize_key( $_GET['type'] ) : '';
+		$taxonomy    = isset( $_GET['taxonomy'] ) ? sanitize_key( $_GET['taxonomy'] ) : '';
+		$post_type   = isset( $_GET['post_type'] ) ? sanitize_key( $_GET['post_type'] ) : '';
+
+		if ( strlen( $search ) < self::MIN_CHARS ) {
+			wp_send_json_error( array( 'message' => __( 'Search term too short.', 'ad-code-manager' ) ) );
+		}
+
+		$results = array();
+
+		if ( 'taxonomy' === $type && ! empty( $taxonomy ) ) {
+			$results = $this->search_taxonomy_terms( $search, $taxonomy );
+		} elseif ( 'post_type' === $type && ! empty( $post_type ) ) {
+			$results = $this->search_posts( $search, $post_type );
+		}
+
+		/**
+		 * Filters the autocomplete search results.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param array  $results     The search results.
+		 * @param string $search      The search term.
+		 * @param string $conditional The conditional function name.
+		 * @param string $type        The search type ('taxonomy' or 'post_type').
+		 */
+		$results = apply_filters( 'acm_autocomplete_results', $results, $search, $conditional, $type );
+
+		wp_send_json_success( array( 'results' => $results ) );
+	}
+
+	/**
+	 * Search for taxonomy terms.
+	 *
+	 * @param string $search   The search term.
+	 * @param string $taxonomy The taxonomy to search.
+	 * @return array<int, array{id: string, text: string}>
+	 */
+	private function search_taxonomy_terms( string $search, string $taxonomy ): array {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'search'     => $search,
+				'number'     => self::MAX_RESULTS,
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return array();
+		}
+
+		$results = array();
+		foreach ( $terms as $term ) {
+			$results[] = array(
+				'id'   => $term->slug,
+				'text' => sprintf( '%s (%s)', $term->name, $term->slug ),
+			);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Search for posts.
+	 *
+	 * @param string $search    The search term.
+	 * @param string $post_type The post type to search.
+	 * @return array<int, array{id: string, text: string}>
+	 */
+	private function search_posts( string $search, string $post_type ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => $post_type,
+				's'              => $search,
+				'posts_per_page' => self::MAX_RESULTS,
+				'post_status'    => 'publish',
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return array();
+		}
+
+		$results = array();
+		foreach ( $posts as $post ) {
+			// For is_page/is_single, we can use ID, slug, or title.
+			$results[] = array(
+				'id'   => (string) $post->ID,
+				'text' => sprintf( '%s (ID: %d)', $post->post_title, $post->ID ),
+			);
+		}
+
+		return $results;
+	}
+}

--- a/src/UI/class-conditional-autocomplete.php
+++ b/src/UI/class-conditional-autocomplete.php
@@ -44,6 +44,13 @@ final class Conditional_Autocomplete {
 	}
 
 	/**
+	 * Select2 version to use from CDN.
+	 *
+	 * @var string
+	 */
+	private const SELECT2_VERSION = '4.0.13';
+
+	/**
 	 * Enqueue scripts and styles for the autocomplete functionality.
 	 *
 	 * @param string $hook_suffix The current admin page hook suffix.
@@ -54,15 +61,35 @@ final class Conditional_Autocomplete {
 			return;
 		}
 
-		// Enqueue Select2 from WordPress (available since WP 4.0).
-		wp_enqueue_script( 'selectWoo' );
+		// Register Select2 from CDN if not already available.
+		// Check for common Select2 handles (selectWoo from WooCommerce, select2 from other plugins).
+		if ( ! wp_script_is( 'selectWoo', 'registered' ) && ! wp_script_is( 'select2', 'registered' ) ) {
+			wp_register_script(
+				'select2',
+				'https://cdn.jsdelivr.net/npm/select2@' . self::SELECT2_VERSION . '/dist/js/select2.min.js',
+				array( 'jquery' ),
+				self::SELECT2_VERSION,
+				true
+			);
+			wp_register_style(
+				'select2',
+				'https://cdn.jsdelivr.net/npm/select2@' . self::SELECT2_VERSION . '/dist/css/select2.min.css',
+				array(),
+				self::SELECT2_VERSION
+			);
+		}
+
+		// Determine which Select2 handle to use (prefer selectWoo if available).
+		$select2_handle = wp_script_is( 'selectWoo', 'registered' ) ? 'selectWoo' : 'select2';
+
+		wp_enqueue_script( $select2_handle );
 		wp_enqueue_style( 'select2' );
 
 		// Enqueue our autocomplete handler.
 		wp_enqueue_script(
 			'acm-conditional-autocomplete',
 			plugins_url( 'acm-autocomplete.js', dirname( __DIR__, 2 ) . '/ad-code-manager.php' ),
-			array( 'jquery', 'selectWoo' ),
+			array( 'jquery', $select2_handle ),
 			filemtime( dirname( __DIR__, 2 ) . '/acm-autocomplete.js' ),
 			true
 		);

--- a/src/class-acm-wp-list-table.php
+++ b/src/class-acm-wp-list-table.php
@@ -273,26 +273,43 @@ class ACM_WP_List_Table extends WP_List_Table {
 				$output .= '<a href="#" class="acm-remove-conditional">Remove</a></div></div>';
 			}
 		}
-		$output .= '</div><div class="form-field form-add-more"><a href="#" class="button button-secondary add-more-conditionals">' . __( 'Add more', 'ad-code-manager' ) . '</a></div>';
+		$output .= '</div><div class="form-field form-add-more"><a href="#" class="button button-secondary add-more-conditionals">' . __( 'Add another condition', 'ad-code-manager' ) . '</a></div>';
+		// Build the field for the logical operator (near conditionals)
+		$condition_count = ! empty( $item['conditionals'] ) ? count( $item['conditionals'] ) : 0;
+		$operator_style  = $condition_count < 2 ? ' style="display:none;"' : '';
+		$output         .= '<div class="acm-operator-field"' . $operator_style . '>';
+		$output         .= '<h4 class="acm-section-label">' . __( 'Logical Operator', 'ad-code-manager' ) . '</h4>';
+		$output         .= '<select name="operator" id="acm-operator">';
+		$operators       = array(
+			'OR'  => __( 'OR', 'ad-code-manager' ),
+			'AND' => __( 'AND', 'ad-code-manager' ),
+		);
+		foreach ( $operators as $key => $label ) {
+			$output .= '<option value="' . esc_attr( $key ) . '" ' . selected( $item['operator'], $key, false ) . '>' . esc_html( $label ) . '</option>';
+		}
+		$output .= '</select>';
+		$output .= '</div>';
 		$output .= '</div>';
 		// Build the fields for the normal columns
 		$output .= '<div class="acm-column-fields">';
 		$output .= '<h4 class="acm-section-label">' . __( 'URL Variables', 'ad-code-manager' ) . '</h4>';
 		foreach ( (array) $item['url_vars'] as $slug => $value ) {
 			$output   .= '<div class="acm-section-single-field">';
-			$column_id = 'acm-column[' . $slug . ']';
-			$output   .= '<label for="' . esc_attr( $column_id ) . '">' . esc_html( $slug ) . '</label>';
-			// Support for select dropdowns
+			$column_id = 'acm-column-' . $slug;
+			// Get the proper label from provider's ad_code_args
 			$ad_code_args = wp_filter_object_list( $ad_code_manager->current_provider->ad_code_args, array( 'key' => $slug ) );
 			$ad_code_arg  = array_shift( $ad_code_args );
+			$field_label  = isset( $ad_code_arg['label'] ) ? $ad_code_arg['label'] : ucwords( str_replace( '_', ' ', $slug ) );
+			$output      .= '<label for="' . esc_attr( $column_id ) . '">' . esc_html( $field_label ) . '</label>';
+			// Support for select dropdowns
 			if ( isset( $ad_code_arg['type'] ) && 'select' == $ad_code_arg['type'] ) {
-				$output .= '<select name="' . esc_attr( $column_id ) . '">';
+				$output .= '<select name="acm-column[' . esc_attr( $slug ) . ']" id="' . esc_attr( $column_id ) . '">';
 				foreach ( $ad_code_arg['options'] as $key => $label ) {
 					$output .= '<option value="' . esc_attr( $key ) . '" ' . selected( $value, $key, false ) . '>' . esc_attr( $label ) . '</option>';
 				}
 				$output .= '</select>';
 			} else {
-				$output .= '<input name="' . esc_attr( $column_id ) . '" id="' . esc_attr( $column_id ) . '" type="text" value="' . esc_attr( $value ) . '" size="20" aria-required="true">';
+				$output .= '<input name="acm-column[' . esc_attr( $slug ) . ']" id="' . esc_attr( $column_id ) . '" type="text" value="' . esc_attr( $value ) . '" size="20" aria-required="true">';
 			}
 			$output .= '</div>';
 		}
@@ -300,20 +317,7 @@ class ACM_WP_List_Table extends WP_List_Table {
 		// Build the field for the priority
 		$output .= '<div class="acm-priority-field">';
 		$output .= '<h4 class="acm-section-label">' . __( 'Priority', 'ad-code-manager' ) . '</h4>';
-		$output .= '<input type="text" name="priority" value="' . esc_attr( $item['priority'] ) . '" />';
-		$output .= '</div>';
-		// Build the field for the logical operator
-		$output   .= '<div class="acm-operator-field">';
-		$output   .= '<h4 class="acm-section-label">' . __( 'Logical Operator', 'ad-code-manager' ) . '</h4>';
-		$output   .= '<select name="operator">';
-		$operators = array(
-			'OR'  => __( 'OR', 'ad-code-manager' ),
-			'AND' => __( 'AND', 'ad-code-manager' ),
-		);
-		foreach ( $operators as $key => $label ) {
-			$output .= '<option ' . selected( $item['operator'], $key ) . '>' . esc_attr( $label ) . '</option>';
-		}
-		$output .= '</select>';
+		$output .= '<input type="text" name="priority" id="acm-priority" value="' . esc_attr( $item['priority'] ) . '" />';
 		$output .= '</div>';
 
 		$output .= '</div>';
@@ -387,9 +391,9 @@ class ACM_WP_List_Table extends WP_List_Table {
 				<div class="acm-float-left">
 				<div class="acm-column-fields"></div>
 				<div class="acm-priority-field"></div>
-				<div class="acm-operator-field"></div>
 				</div>
 				<div class="acm-conditional-fields"></div>
+				<div class="acm-operator-field"></div>
 				<div class="clear"></div>
 			</div></fieldset>
 		<p class="inline-edit-save submit">

--- a/tests/Integration/UI/ConditionalAutocompleteTest.php
+++ b/tests/Integration/UI/ConditionalAutocompleteTest.php
@@ -31,6 +31,12 @@ final class ConditionalAutocompleteTest extends TestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
+
+		// Ensure scripts are dequeued at the start of each test.
+		wp_dequeue_script( 'acm-conditional-autocomplete' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
+
 		$this->autocomplete = new Conditional_Autocomplete();
 	}
 
@@ -228,6 +234,12 @@ final class ConditionalAutocompleteTest extends TestCase {
 	 */
 	public function tear_down(): void {
 		unset( $_GET['search'], $_GET['conditional'], $_GET['type'], $_GET['taxonomy'], $_GET['post_type'], $_GET['nonce'] );
+
+		// Dequeue scripts to prevent test pollution.
+		wp_dequeue_script( 'acm-conditional-autocomplete' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
+
 		parent::tear_down();
 	}
 }

--- a/tests/Integration/UI/ConditionalAutocompleteTest.php
+++ b/tests/Integration/UI/ConditionalAutocompleteTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for the Conditional Autocomplete functionality.
+ *
+ * @package Automattic\AdCodeManager\Tests\Integration\UI
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\AdCodeManager\Tests\Integration\UI;
+
+use Automattic\AdCodeManager\Tests\Integration\TestCase;
+use Automattic\AdCodeManager\UI\Conditional_Autocomplete;
+use ReflectionClass;
+use WP_Term;
+
+/**
+ * Tests for the Conditional Autocomplete class.
+ */
+final class ConditionalAutocompleteTest extends TestCase {
+
+	/**
+	 * Instance of the class under test.
+	 *
+	 * @var Conditional_Autocomplete
+	 */
+	private Conditional_Autocomplete $autocomplete;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->autocomplete = new Conditional_Autocomplete();
+	}
+
+	/**
+	 * Test that the run method registers the necessary hooks.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete::run
+	 */
+	public function test_run_registers_hooks(): void {
+		$this->autocomplete->run();
+
+		self::assertNotFalse(
+			has_action( 'admin_enqueue_scripts', array( $this->autocomplete, 'enqueue_scripts' ) )
+		);
+		self::assertNotFalse(
+			has_action( 'wp_ajax_acm_search_terms', array( $this->autocomplete, 'ajax_search_terms' ) )
+		);
+	}
+
+	/**
+	 * Test that scripts are not enqueued on non-ACM pages.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete::enqueue_scripts
+	 */
+	public function test_scripts_not_enqueued_on_other_pages(): void {
+		$this->autocomplete->enqueue_scripts( 'edit.php' );
+
+		self::assertFalse( wp_script_is( 'acm-conditional-autocomplete', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the acm_autocomplete_conditionals filter is applied.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_autocomplete_conditionals_filter(): void {
+		$filter_called = false;
+		$custom_conditionals = array(
+			'custom_conditional' => array(
+				'type'     => 'taxonomy',
+				'taxonomy' => 'custom_tax',
+			),
+		);
+
+		add_filter(
+			'acm_autocomplete_conditionals',
+			function ( $conditionals ) use ( &$filter_called, $custom_conditionals ) {
+				$filter_called = true;
+				return array_merge( $conditionals, $custom_conditionals );
+			}
+		);
+
+		// Trigger script enqueue to get the conditionals.
+		set_current_screen( 'settings_page_ad-code-manager' );
+		$this->autocomplete->enqueue_scripts( 'settings_page_ad-code-manager' );
+
+		self::assertTrue( $filter_called );
+	}
+
+	/**
+	 * Test default autocomplete conditionals include expected entries.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_default_autocomplete_conditionals(): void {
+		// Use reflection to access the private method.
+		$reflection = new ReflectionClass( $this->autocomplete );
+		$method = $reflection->getMethod( 'get_autocomplete_conditionals' );
+		$method->setAccessible( true );
+
+		$conditionals = $method->invoke( $this->autocomplete );
+
+		// Verify expected conditionals are present.
+		self::assertArrayHasKey( 'is_category', $conditionals );
+		self::assertArrayHasKey( 'has_category', $conditionals );
+		self::assertArrayHasKey( 'is_tag', $conditionals );
+		self::assertArrayHasKey( 'has_tag', $conditionals );
+		self::assertArrayHasKey( 'is_page', $conditionals );
+		self::assertArrayHasKey( 'is_single', $conditionals );
+
+		// Verify structure of a taxonomy conditional.
+		self::assertEquals( 'taxonomy', $conditionals['is_category']['type'] );
+		self::assertEquals( 'category', $conditionals['is_category']['taxonomy'] );
+
+		// Verify structure of a post_type conditional.
+		self::assertEquals( 'post_type', $conditionals['is_page']['type'] );
+		self::assertEquals( 'page', $conditionals['is_page']['post_type'] );
+	}
+
+	/**
+	 * Test taxonomy term search.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_search_taxonomy_terms(): void {
+		// Create test categories.
+		self::factory()->category->create( array( 'name' => 'Technology News' ) );
+		self::factory()->category->create( array( 'name' => 'Tech Reviews' ) );
+		self::factory()->category->create( array( 'name' => 'Sports' ) );
+
+		// Use reflection to access the private method.
+		$reflection = new ReflectionClass( $this->autocomplete );
+		$method = $reflection->getMethod( 'search_taxonomy_terms' );
+		$method->setAccessible( true );
+
+		$results = $method->invoke( $this->autocomplete, 'Tech', 'category' );
+
+		self::assertCount( 2, $results );
+		self::assertArrayHasKey( 'id', $results[0] );
+		self::assertArrayHasKey( 'text', $results[0] );
+	}
+
+	/**
+	 * Test post search.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_search_posts(): void {
+		// Create test pages.
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'About Us',
+				'post_status' => 'publish',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'About Our Team',
+				'post_status' => 'publish',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Contact',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Use reflection to access the private method.
+		$reflection = new ReflectionClass( $this->autocomplete );
+		$method = $reflection->getMethod( 'search_posts' );
+		$method->setAccessible( true );
+
+		$results = $method->invoke( $this->autocomplete, 'About', 'page' );
+
+		self::assertCount( 2, $results );
+		self::assertArrayHasKey( 'id', $results[0] );
+		self::assertArrayHasKey( 'text', $results[0] );
+	}
+
+	/**
+	 * Test empty search returns empty array.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_search_no_results(): void {
+		// Use reflection to access the private method.
+		$reflection = new ReflectionClass( $this->autocomplete );
+		$method = $reflection->getMethod( 'search_taxonomy_terms' );
+		$method->setAccessible( true );
+
+		$results = $method->invoke( $this->autocomplete, 'NonexistentTerm', 'category' );
+
+		self::assertIsArray( $results );
+		self::assertEmpty( $results );
+	}
+
+	/**
+	 * Test search for tags returns correct structure.
+	 *
+	 * @covers \Automattic\AdCodeManager\UI\Conditional_Autocomplete
+	 */
+	public function test_search_tags(): void {
+		// Create test tags.
+		self::factory()->tag->create( array( 'name' => 'WordPress Tips' ) );
+		self::factory()->tag->create( array( 'name' => 'WordPress Plugins' ) );
+
+		// Use reflection to access the private method.
+		$reflection = new ReflectionClass( $this->autocomplete );
+		$method = $reflection->getMethod( 'search_taxonomy_terms' );
+		$method->setAccessible( true );
+
+		$results = $method->invoke( $this->autocomplete, 'WordPress', 'post_tag' );
+
+		self::assertCount( 2, $results );
+		// Results should use slug as ID.
+		self::assertStringContainsString( 'wordpress', $results[0]['id'] );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		unset( $_GET['search'], $_GET['conditional'], $_GET['type'], $_GET['taxonomy'], $_GET['post_type'], $_GET['nonce'] );
+		parent::tear_down();
+	}
+}

--- a/views/ad-code-manager.tpl.php
+++ b/views/ad-code-manager.tpl.php
@@ -41,6 +41,43 @@
 	}
 	?>
 	<p><?php esc_html_e( 'Refer to help section for more information.', 'ad-code-manager' ); ?></p>
+<?php
+// Only show the provider selector if one hasn't been specified at the code level.
+if ( ! apply_filters( 'acm_provider_slug', false ) ) :
+	?>
+<div class="acm-global-options">
+	<h2><?php esc_html_e( 'Configuration', 'ad-code-manager' ); ?></h2>
+	<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" name="updatesettings" id="updatesettings" class="acm-config-form">
+	<p>
+		<label for="provider"><?php esc_html_e( 'Provider:', 'ad-code-manager' ); ?></label>
+		<select name="provider" id="provider">
+		<?php
+		$current_provider = $this->get_option( 'provider' );
+		foreach ( $this->providers as $slug => $provider ) :
+			$label = $provider['label'] ?? ucwords( str_replace( '_', ' ', $slug ) );
+			?>
+			<option value="<?php echo esc_attr( $slug ); ?>" <?php selected( $slug, $current_provider ); ?>><?php echo esc_html( $label ); ?></option>
+		<?php endforeach; ?>
+		</select>
+		<?php
+		/**
+		 * Fires after the provider select field in the ACM options form.
+		 *
+		 * Use this action to add custom fields to the Configuration section
+		 * of the Ad Code Manager admin page.
+		 *
+		 * @since 0.4
+		 */
+		do_action( 'acm_options_form' );
+		?>
+		<input type="hidden" name="action" value="acm_admin_action" />
+		<input type="hidden" name="method" value="update_options" />
+		<?php wp_nonce_field( 'acm-admin-action', 'nonce' ); ?>
+		<?php submit_button( __( 'Save Options', 'ad-code-manager' ), 'primary', 'submit', false ); ?>
+	</p>
+	</form>
+</div>
+<?php endif; ?>
 	</div>
 
 <div class="wrap nosubsub">
@@ -48,6 +85,7 @@
 
 <div id="col-right">
 <div class="col-wrap">
+	<h2><?php esc_html_e( 'Existing Ad Codes', 'ad-code-manager' ); ?></h2>
 	<form action="" method="post" name="updateadcodes" id="updateadcodes">
 <?php
 wp_nonce_field( 'acm-bulk-action', 'bulk-action-nonce' );
@@ -64,45 +102,6 @@ $this->wp_list_table->display();
 
 
 <div class="form-wrap">
-<?php
-// Only show the provider selector if one hasn't been specified at the code level.
-if ( ! apply_filters( 'acm_provider_slug', false ) ) :
-	?>
-<div class="acm-global-options">
-	<h2><?php esc_html_e( 'Configuration', 'ad-code-manager' ); ?></h2>
-	<div class="form-wrap">
-	<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post" name="updatesettings" id="updatesettings">
-	<div id="provider-field" class="form-field form-required">
-		<label for="provider"><?php esc_html_e( 'Select a provider:', 'ad-code-manager' ); ?></label>
-		<select name="provider" id="provider">
-		<?php
-		$current_provider = $this->get_option( 'provider' );
-		foreach ( $this->providers as $slug => $provider ) :
-			$label = $provider['label'] ?? ucwords( str_replace( '_', ' ', $slug ) );
-			?>
-			<option value="<?php echo esc_attr( $slug ); ?>" <?php selected( $slug, $current_provider ); ?>><?php echo esc_html( $label ); ?></option>
-		<?php endforeach; ?>
-		</select>
-	</div>
-		<?php
-		/**
-		 * Fires after the provider select field in the ACM options form.
-		 *
-		 * Use this action to add custom fields to the Configuration section
-		 * of the Ad Code Manager admin page.
-		 *
-		 * @since 0.4
-		 */
-		do_action( 'acm_options_form' );
-		?>
-		<input type="hidden" name="action" value="acm_admin_action" />
-		<input type="hidden" name="method" value="update_options" />
-		<?php wp_nonce_field( 'acm-admin-action', 'nonce' ); ?>
-		<?php submit_button( __( 'Save Options', 'ad-code-manager' ) ); ?>
-	</form>
-	</div>
-</div>
-<?php endif; ?>
 <h2><?php esc_html_e( 'Add New Ad Code', 'ad-code-manager' ); ?></h2>
 <form id="add-adcode" method="POST" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" class="validate">
 <input type="hidden" name="action" value="acm_admin_action" />
@@ -164,7 +163,7 @@ foreach ( $this->whitelisted_conditionals as $key ) :
 	</div>
 </div>
 <div class="form-field form-add-more">
-	<a href="#" class="button button-secondary add-more-conditionals"><?php esc_html_e( 'Add more', 'ad-code-manager' ); ?></a>
+	<a href="#" class="button button-secondary add-more-conditionals"><?php esc_html_e( 'Add another condition', 'ad-code-manager' ); ?></a>
 </div>
 </div>
 <p class="clear"></p>


### PR DESCRIPTION
## Summary

- Adds Select2-based autocomplete for conditional arguments (categories, tags, pages, posts) in the **Add New Ad Code** form
- Uses Select2 loaded from jsDelivr CDN (with graceful fallback if unavailable)
- Implements AJAX search with 3-character minimum and 100 result limit as suggested in issue discussion
- Hides arguments field for conditionals that don't take parameters (is_home, is_front_page, etc.)
- Improves admin UI layout: Configuration section full-width, "Existing Ad Codes" heading, better field labels in Edit view
- Extensible via `acm_autocomplete_conditionals` and `acm_autocomplete_results` filters

**Note:** Autocomplete is currently only enabled for the Add form. The inline Edit form retains text inputs - a dedicated edit page is planned as a follow-up improvement (see #198).

## Test plan

- [ ] Navigate to Ad Code Manager settings page
- [ ] In "Add New Ad Code", select a conditional like `is_category` or `is_tag`
- [ ] Verify the argument input becomes a Select2 autocomplete field
- [ ] Type 3+ characters and verify suggestions appear via AJAX
- [ ] Select a suggestion and verify it's applied
- [ ] Verify custom values can still be typed if not in autocomplete results
- [ ] Select `is_home` or `is_front_page` and verify arguments field is hidden
- [ ] Verify "Add another condition" button only appears after first condition is selected
- [ ] Run `composer test:integration` - all 28 tests should pass

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)