### PR TITLE
fix: deployment and distribution archive improvements

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 # Directories
 /.git/
 /.github/
+/.wordpress-org/
 /bin/
 /node_modules/
 /tests/

--- a/.gitattributes
+++ b/.gitattributes
@@ -19,10 +19,14 @@
 /vendor                          export-ignore
 
 # Files
+/.distignore                     export-ignore
 /.editorconfig                   export-ignore
 /.gitattributes                  export-ignore
 /.gitignore                      export-ignore
+/.npmrc                          export-ignore
 /.phpcs.xml.dist                 export-ignore
+/.wp-env.json                    export-ignore
+/.wp-env.override.json           export-ignore
 /CHANGELOG.md                    export-ignore
 /clover.xml                      export-ignore
 /composer.json                   export-ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install SVN (Subversion)
-        run: |
-          sudo apt-get update
-          sudo apt-get install subversion
-
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:


### PR DESCRIPTION
## Summary

Two fixes for deployment and distribution:

1. **Remove manual SVN installation from deploy workflow** - The 10up/action-wordpress-plugin-deploy action includes SVN installation, making the manual apt-get step redundant.

2. **Exclude dev files from distribution archives** - Add missing entries to `.distignore` and `.gitattributes`:
   - `.wordpress-org/` directory (was appearing in WordPress.org zip)
   - `.distignore`, `.npmrc`, `.wp-env.json`, `.wp-env.override.json` files (were appearing in GitHub release archives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)